### PR TITLE
Bump source-map-list to 0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "source-map": "~0.5.3",
-    "source-list-map": "~0.1.0"
+    "source-list-map": "~0.1.7"
   },
   "devDependencies": {
     "beautify-lint": "^1.0.3",


### PR DESCRIPTION
Per https://github.com/facebookincubator/create-react-app/pull/1101#issuecomment-264865954, we would like to make sure https://github.com/webpack/source-list-map/pull/3 ships to Webpack users without deleting `node_modules` and reinstalling.

Webpack 1.x PR is in https://github.com/webpack/core/pull/30.