### PR TITLE
Improve performance of ConcatSource

### DIFF
--- a/lib/ConcatSource.js
+++ b/lib/ConcatSource.js
@@ -20,44 +20,63 @@ ConcatSource.prototype.add = function(item) {
 };
 
 ConcatSource.prototype.source = function() {
-	return this.children.map(function(item) {
-		return typeof item === "string" ? item : item.source();
-	}).join("");
+	var source = '';
+
+	var children = this.children;
+	for(var i = 0, l = children.length; i < l; ++i) {
+		var item = children[i];
+		source += typeof item === "string" ? item : item.source();
+	}
+
+	return source;
 };
 
 ConcatSource.prototype.size = function() {
-	return this.children.map(function(item) {
-		return typeof item === "string" ? item.length : item.size();
-	}).reduce(function(sum, s) {
-		return sum + s;
-	}, 0);
+	var size = 0;
+
+	var children = this.children;
+	for(var i = 0, l = children.length; i < l; ++i) {
+		var item = children[i];
+		size += typeof item === "string" ? item.length : item.size();
+	}
+
+	return size;
 };
 
 require("./SourceAndMapMixin")(ConcatSource.prototype);
 
 ConcatSource.prototype.node = function(options) {
-	var node = new SourceNode(null, null, null, this.children.map(function(item) {
-		return typeof item === "string" ? item : item.node(options);
-	}));
-	return node;
+	var chunks = [];
+
+	var children = this.children;
+	for(var i = 0, l = children.length; i < l; ++i) {
+		var item = children[i];
+		chunks.push(typeof item === "string" ? item : item.node(options));
+	}
+
+	return new SourceNode(null, null, null, chunks);
 };
 
 ConcatSource.prototype.listMap = function(options) {
 	var map = new SourceListMap();
-	this.children.forEach(function(item) {
-		if(typeof item === "string")
-			map.add(item);
-		else
-			map.add(item.listMap(options));
-	});
+
+	var children = this.children;
+	for(var i = 0, l = children.length; i < l; ++i) {
+		var item = children[i];
+		map.add(typeof item === "string" ? item : item.listMap(options));
+	}
+
 	return map;
 };
 
 ConcatSource.prototype.updateHash = function(hash) {
-	this.children.forEach(function(item) {
-		if(typeof item === "string")
+	var children = this.children;
+	for(var i = 0, l = children.length; i < l; ++i) {
+		var item = children[i];
+		if(typeof item === "string") {
 			hash.update(item);
-		else
+		} else {
 			item.updateHash(hash);
-	});
+		}
+	}
 };


### PR DESCRIPTION
This PR replaces .map, .forEach and .reduce in ConcatSource with normal for loops which are much faster (in some tests I made with Node 7, between 30-40 times), even if uglier to look at and to longer to write. Since some of these loops are run a lot of times for large projects, I think it is worth it to optimize them as much as possible.

While I haven't had the chance to look deeper into the rest of webpack, I am pretty sure there are more optimization opportunities like these in places that get executed a lot.