### PR TITLE
fix(SourceMapSource): default options to empty object

### DIFF
--- a/lib/SourceMapSource.js
+++ b/lib/SourceMapSource.js
@@ -43,6 +43,7 @@ SourceMapSource.prototype.node = function(options) {
 };
 
 SourceMapSource.prototype.listMap = function(options) {
+	options = options || {};
 	if(options.module === false)
 		return new SourceListMap(this._value, this._name, this._value);
 	return fromStringWithSourceMap(this._value, typeof this._sourceMap === "string" ? JSON.parse(this._sourceMap) : this._sourceMap);


### PR DESCRIPTION
`listMap` isn't really documented, so not sure if it's supposed to be private, but this looks like the only place that options isn't defaulted to empty in here (and SourceMapSource is the only one that will fail when calling `source.listMap()`)