### PR TITLE
Update source-map

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "source-list-map": "^2.0.0",
-    "source-map": "~0.5.3"
+    "source-map": "~0.6.1"
   },
   "devDependencies": {
     "beautify-lint": "^1.0.3",


### PR DESCRIPTION
Hi! This applies the fix as identified in https://github.com/mozilla/source-map/issues/247

I've got a project that fails to build with the `TypeError: Cannot read property 'substr' of undefined` error as outlined in the above link. Manually updating `source-map` resolves it, and unfortunately we can't build our project until `webpack-sources` uses this version.

Thanks!