### PR TITLE
reducing memory allocation in ConcatSource and ReplaceSource

### DIFF
--- a/lib/ConcatSource.js
+++ b/lib/ConcatSource.js
@@ -28,7 +28,7 @@ class ConcatSource extends Source {
 	}
 
 	size() {
-		let size = "";
+		let size = 0;
 		for(let i = 0, len = this.children.length; i < len; ++i) {
 			const child = this.children[i];
 			size += (typeof child === "string") ? child.length : child.size();

--- a/lib/ConcatSource.js
+++ b/lib/ConcatSource.js
@@ -20,7 +20,7 @@ class ConcatSource extends Source {
 
 	source() {
 		let source = "";
-		for (let i = 0, len = this.children.length; i < len; ++i) {
+		for(let i = 0, len = this.children.length; i < len; ++i) {
 			const child = this.children[i];
 			source += (typeof child === "string") ? child : child.source();
 		}
@@ -29,7 +29,7 @@ class ConcatSource extends Source {
 
 	size() {
 		let size = "";
-		for (let i = 0, len = this.children.length; i < len; ++i) {
+		for(let i = 0, len = this.children.length; i < len; ++i) {
 			const child = this.children[i];
 			size += (typeof child === "string") ? child.length : child.size();
 		}

--- a/lib/ConcatSource.js
+++ b/lib/ConcatSource.js
@@ -19,17 +19,21 @@ class ConcatSource extends Source {
 	}
 
 	source() {
-		return this.children.map(function(item) {
-			return typeof item === "string" ? item : item.source();
-		}).join("");
+		let source = "";
+		for (let i = 0, len = this.children.length; i < len; ++i) {
+			const child = this.children[i];
+			source += (typeof child === "string") ? child : child.source();
+		}
+		return source;
 	}
 
 	size() {
-		return this.children.map(function(item) {
-			return typeof item === "string" ? item.length : item.size();
-		}).reduce(function(sum, s) {
-			return sum + s;
-		}, 0);
+		let size = "";
+		for (let i = 0, len = this.children.length; i < len; ++i) {
+			const child = this.children[i];
+			size += (typeof child === "string") ? child.length : child.size();
+		}
+		return size;
 	}
 
 	node(options) {

--- a/lib/ReplaceSource.js
+++ b/lib/ReplaceSource.js
@@ -61,8 +61,13 @@ class ReplaceSource extends Source {
 			var splitted2 = this._splitString(splitted1[0], Math.floor(repl[0]));
 			result.push(splitted1[1], repl[2], splitted2[0]);
 		}, this);
-		result = result.reverse();
-		return result.join("");
+
+		// write out result array in reverse order
+		let resultStr = "";
+		for (let i = result.length - 1; i >= 0; --i) {
+			resultStr += result[i];
+		}
+		return resultStr;
 	}
 
 	node(options) {

--- a/lib/ReplaceSource.js
+++ b/lib/ReplaceSource.js
@@ -64,7 +64,7 @@ class ReplaceSource extends Source {
 
 		// write out result array in reverse order
 		let resultStr = "";
-		for (let i = result.length - 1; i >= 0; --i) {
+		for(let i = result.length - 1; i >= 0; --i) {
 			resultStr += result[i];
 		}
 		return resultStr;


### PR DESCRIPTION
using (+=) operator instead of array join/reduce to reduce memory allocation.

This causes nodejs to treat the strings internally as "concatenated strings"
and reuse the pieces instead of allocating new memory.
see: https://github.com/webpack/webpack-sources/issues/30

For the ConcatSource::size() change, we are simply removing the need to allocate an array to compute the size.