### PR TITLE
Make ConcatSource .add method chainable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /coverage
+.idea

--- a/lib/ConcatSource.js
+++ b/lib/ConcatSource.js
@@ -32,6 +32,7 @@ class ConcatSource extends Source {
 		} else {
 			this.children.push(item);
 		}
+		return this;
 	}
 
 	source() {

--- a/test/ConcatSource.js
+++ b/test/ConcatSource.js
@@ -103,4 +103,23 @@ describe("ConcatSource", function() {
 		var digest = hash.digest('hex')
 		digest.should.be.eql('c7172c1aa78e1ab61b365fadb9b6f192a770c2b91c8b5c65314b4911431a1a31')
 	})
+
+	it('should be able to add in chain', function() {
+		var source = new ConcatSource(
+			new RawSource("Hello World\n"),
+			new OriginalSource("console.log('test');\nconsole.log('test2');\n", "console.js")
+		);
+		source.add("console.log('string');\n")
+			.add("console.log('string2')");
+
+		var expectedSource = [
+			"Hello World",
+			"console.log('test');",
+			"console.log('test2');",
+			"console.log('string');",
+			"console.log('string2')",
+		].join("\n");
+		source.size().should.be.eql(100);
+		source.source().should.be.eql(expectedSource);
+	})
 });


### PR DESCRIPTION
I wanted to improve the webpack's source code, one of the wins here is that we can replace things like:

```
source.add(`exports.ids = ${JSON.stringify(chunk.ids)};\nexports.modules = `);
source.add(modules);
source.add(";");
```

with:
```
source.add(`exports.ids = ${JSON.stringify(chunk.ids)};\nexports.modules = `)
  .add(modules)
  .add(";");
```

If you think its worthy lets merge and i will do refactoring in the main repo

*Test added*
*Non breaking change*

cc @sokra 