### PR TITLE
Improvements on OriginalSource and ReplaceSource

### DIFF
--- a/lib/OriginalSource.js
+++ b/lib/OriginalSource.js
@@ -9,32 +9,10 @@ var SourceMapConsumer = require("source-map").SourceMapConsumer;
 var SourceListMap = require("source-list-map").SourceListMap;
 var Source = require("./Source");
 
-function isSplitter(c) {
-	switch(c) {
-		case 10: // \n
-		case 13: // \r
-		case 59: // ;
-		case 123: // {
-		case 125: // }
-			return true;
-	}
-	return false;
-}
+var SPLIT_REGEX = /(?!$)[^\n\r;{}]*[\n\r;{}]*/g;
 
 function _splitCode(code) {
-	var result = [];
-	var i = 0;
-	var j = 0;
-	for(; i < code.length; i++) {
-		if(isSplitter(code.charCodeAt(i))) {
-			while(isSplitter(code.charCodeAt(++i)));
-			result.push(code.substring(j, i));
-			j = i;
-		}
-	}
-	if(j < code.length)
-		result.push(code.substr(j));
-	return result;
+	return code.match(SPLIT_REGEX) || [];
 }
 
 class OriginalSource extends Source {

--- a/lib/ReplaceSource.js
+++ b/lib/ReplaceSource.js
@@ -75,7 +75,7 @@ class ReplaceSource extends Source {
 		if(this.replacements.length === 0) {
 			return node;
 		}
-		this.replacements.sort(sortReplacementsAscending);
+		this._sortReplacements();
 		var replace = new ReplacementEnumerator(this.replacements);
 		var output = [];
 		var position = 0;
@@ -258,29 +258,14 @@ class ReplaceSource extends Source {
 	}
 }
 
-function sortReplacementsAscending(a, b) {
-	var diff = a[1] - b[1]; // end
-	if(diff !== 0)
-		return diff;
-	diff = a[0] - b[0]; // start
-	if(diff !== 0)
-		return diff;
-	return a[3] - b[3]; // insert order
-}
-
 class ReplacementEnumerator {
 	constructor(replacements) {
-		this.emit = true;
-		this.done = !replacements || replacements.length === 0;
-		this.index = 0;
-		this.replacements = replacements;
-		if(!this.done) {
-			// Set initial start position in case .header is not called
-			var repl = replacements[0];
-			this.position = Math.floor(repl[0]);
-			if(this.position < 0)
-				this.position = 0;
-		}
+		this.replacements = replacements || [];
+		this.index = this.replacements.length;
+		this.done = false;
+		this.emit = false;
+		// Set initial start position
+		this.next();
 	}
 
 	next() {
@@ -294,8 +279,8 @@ class ReplacementEnumerator {
 			this.value = repl[2];
 		} else {
 			// End point found. start emitting. set position to find next start
-			this.index++;
-			if(this.index >= this.replacements.length) {
+			this.index--;
+			if(this.index < 0) {
 				this.done = true;
 			} else {
 				var nextRepl = this.replacements[this.index];
@@ -312,9 +297,16 @@ class ReplacementEnumerator {
 	footer() {
 		if(!this.done && !this.emit)
 			this.next(); // If we finished _replaceInNode mid emit we advance to next entry
-		return this.done ? [] : this.replacements.slice(this.index).map(function(repl) {
-			return repl[2];
-		}).join("");
+		if(this.done) {
+			return [];
+		} else {
+			var resultStr = "";
+			for(var i = this.index; i >= 0; i--) {
+				var repl = this.replacements[i];
+				resultStr += repl[2];
+			}
+			return resultStr;
+		}
 	}
 }
 

--- a/test/OriginalSource.js
+++ b/test/OriginalSource.js
@@ -1,0 +1,59 @@
+var should = require("should");
+var OriginalSource = require("../lib/OriginalSource");
+
+describe("OriginalSource", function() {
+	it("should handle multiline string", function() {
+		var source = new OriginalSource("Line1\n\nLine3\n", "file.js");
+		var resultText = source.source();
+		var resultMap = source.sourceAndMap({
+			columns: true
+		});
+		var resultListMap = source.sourceAndMap({
+			columns: false
+		});
+
+		resultText.should.be.eql("Line1\n\nLine3\n");
+		resultMap.source.should.be.eql(resultText);
+		resultListMap.source.should.be.eql(resultText);
+		resultListMap.map.file.should.be.eql(resultMap.map.file);
+		resultListMap.map.version.should.be.eql(resultMap.map.version);
+		resultMap.map.sources.should.be.eql(["file.js"]);
+		resultListMap.map.sources.should.be.eql(resultMap.map.sources);
+		resultMap.map.sourcesContent.should.be.eql(["Line1\n\nLine3\n"]);
+		resultListMap.map.sourcesContent.should.be.eql(resultMap.map.sourcesContent);
+		resultMap.map.mappings.should.be.eql("AAAA;;AAEA");
+		resultListMap.map.mappings.should.be.eql("AAAA;AACA;AACA;");
+	});
+
+	it("should handle empty string", function() {
+		var source = new OriginalSource("", "file.js");
+		var resultText = source.source();
+		var resultMap = source.sourceAndMap({
+			columns: true
+		});
+		var resultListMap = source.sourceAndMap({
+			columns: false
+		});
+
+		resultText.should.be.eql("");
+		resultMap.source.should.be.eql(resultText);
+		resultListMap.source.should.be.eql(resultText);
+		resultListMap.map.file.should.be.eql(resultMap.map.file);
+		resultListMap.map.version.should.be.eql(resultMap.map.version);
+		resultMap.map.sources.should.be.eql([]);
+		resultListMap.map.sources.should.be.eql(resultMap.map.sources);
+		resultMap.map.mappings.should.be.eql("");
+		resultListMap.map.mappings.should.be.eql("");
+	});
+
+	it("should omit mappings for columns with node", function() {
+		var source = new OriginalSource("Line1\n\nLine3\n", "file.js");
+		var resultMap = source.node({
+			columns: false
+		}).toStringWithSourceMap({
+			file: "x"
+		}).map.toJSON();
+
+		resultMap.mappings.should.be.eql("AAAA;AACA;AACA");
+	});
+});


### PR DESCRIPTION
**OriginalSource**
Use `str.match(regexp)` in `_splitCode`, which is faster than string traversal with for loop

**RepalceSource**
Make `ReplacementEnumerator` take the replacements in descending order and remove redundant code.