### PR TITLE
Support for binary files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ All methods should be considered as expensive as they may need to do computation
 #### `source`
 
 ``` js
-Source.prototype.source() -> String
+Source.prototype.source() -> String | ArrayBuffer
 ```
 
 Returns the represented source code as string.

--- a/lib/CachedSource.js
+++ b/lib/CachedSource.js
@@ -30,8 +30,10 @@ class CachedSource extends Source {
 
 	size() {
 		if(typeof this._cachedSize !== "undefined") return this._cachedSize;
-		if(typeof this._cachedSource !== "undefined")
-			return this._cachedSize = Buffer.from(this._cachedSource).length;
+		if(typeof this._cachedSource !== "undefined") {
+			if(Buffer.from) return this._cachedSize = Buffer.from(this._cachedSource).length;
+			return this._cachedSize = new Buffer(this.CachedSource).length;
+		}
 		return this._cachedSize = this._source.size();
 	}
 

--- a/lib/CachedSource.js
+++ b/lib/CachedSource.js
@@ -30,8 +30,11 @@ class CachedSource extends Source {
 
 	size() {
 		if(typeof this._cachedSize !== "undefined") return this._cachedSize;
-		if(typeof this._cachedSource !== "undefined")
+		if(typeof this._cachedSource !== "undefined") {
+			if(this._cachedSource instanceof ArrayBuffer)
+				return this._cachedSize = this._cachedSource.byteLength;
 			return this._cachedSize = this._cachedSource.length;
+		}
 		return this._cachedSize = this._source.size();
 	}
 

--- a/lib/CachedSource.js
+++ b/lib/CachedSource.js
@@ -30,11 +30,8 @@ class CachedSource extends Source {
 
 	size() {
 		if(typeof this._cachedSize !== "undefined") return this._cachedSize;
-		if(typeof this._cachedSource !== "undefined") {
-			if(this._cachedSource instanceof ArrayBuffer)
-				return this._cachedSize = this._cachedSource.byteLength;
-			return this._cachedSize = this._cachedSource.length;
-		}
+		if(typeof this._cachedSource !== "undefined")
+			return this._cachedSize = Buffer.from(this._cachedSource).length;
 		return this._cachedSize = this._source.size();
 	}
 

--- a/lib/CachedSource.js
+++ b/lib/CachedSource.js
@@ -31,8 +31,8 @@ class CachedSource extends Source {
 	size() {
 		if(typeof this._cachedSize !== "undefined") return this._cachedSize;
 		if(typeof this._cachedSource !== "undefined") {
-			if(Buffer.from) return this._cachedSize = Buffer.from(this._cachedSource).length;
-			return this._cachedSize = new Buffer(this.CachedSource).length;
+			if(Buffer.from.length === 1) return new Buffer(this.source()).length;
+			return this._cachedSize = Buffer.byteLength(this._cachedSource);
 		}
 		return this._cachedSize = this._source.size();
 	}

--- a/lib/CachedSource.js
+++ b/lib/CachedSource.js
@@ -31,7 +31,7 @@ class CachedSource extends Source {
 	size() {
 		if(typeof this._cachedSize !== "undefined") return this._cachedSize;
 		if(typeof this._cachedSource !== "undefined") {
-			if(Buffer.from.length === 1) return new Buffer(this.source()).length;
+			if(Buffer.from.length === 1) return new Buffer(this._cachedSource).length;
 			return this._cachedSize = Buffer.byteLength(this._cachedSource);
 		}
 		return this._cachedSize = this._source.size();

--- a/lib/ReplaceSource.js
+++ b/lib/ReplaceSource.js
@@ -266,7 +266,7 @@ class ReplaceSource extends Source {
 			// Recurse with remainder of the string as there may be multiple replaces within a single node
 			node = node.substr(splitPosition);
 			position += splitPosition;
-		} while(true);
+		} while (true);
 	}
 }
 

--- a/lib/ReplaceSource.js
+++ b/lib/ReplaceSource.js
@@ -266,7 +266,7 @@ class ReplaceSource extends Source {
 			// Recurse with remainder of the string as there may be multiple replaces within a single node
 			node = node.substr(splitPosition);
 			position += splitPosition;
-		} while (true);
+		} while(true);
 	}
 }
 

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -14,8 +14,8 @@ class Source {
 	}
 
 	size() {
-		if(Buffer.from) return Buffer.from(this.source()).length;
-		return new Buffer(this.source()).length
+		if(Buffer.from.length === 1) return new Buffer(this.source()).length;
+		return Buffer.byteLength(this.source())
 	}
 
 	map(options) {

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -14,6 +14,7 @@ class Source {
 	}
 
 	size() {
+		if(this.source() instanceof ArrayBuffer) return this.source().byteLength;
 		return this.source().length;
 	}
 

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -14,8 +14,7 @@ class Source {
 	}
 
 	size() {
-		if(this.source() instanceof ArrayBuffer) return this.source().byteLength;
-		return this.source().length;
+		return Buffer.from(this.source()).length;
 	}
 
 	map(options) {

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -14,7 +14,8 @@ class Source {
 	}
 
 	size() {
-		return Buffer.from(this.source()).length;
+		if(Buffer.from) return Buffer.from(this.source()).length;
+		return new Buffer(this.source()).length
 	}
 
 	map(options) {

--- a/test/CachedSource.js
+++ b/test/CachedSource.js
@@ -8,5 +8,14 @@ describe("CachedSource", function() {
 		var cachedSource = new CachedSource(source);
 
 		cachedSource.size().should.be.eql(256);
+		cachedSource.size().should.be.eql(256);
+	});
+
+	it("should return the correct size for text files", function() {
+		var source = new OriginalSource("TestTestTest", "file.js");
+		var cachedSource = new CachedSource(source);
+
+		cachedSource.size().should.be.eql(12);
+		cachedSource.size().should.be.eql(12);
 	});
 });

--- a/test/CachedSource.js
+++ b/test/CachedSource.js
@@ -11,10 +11,28 @@ describe("CachedSource", function() {
 		cachedSource.size().should.be.eql(256);
 	});
 
+	it("should return the correct size for cached binary sources", function() {
+		var source = new OriginalSource(new ArrayBuffer(256), "file.wasm");
+		var cachedSource = new CachedSource(source);
+
+		cachedSource.source();
+		cachedSource.size().should.be.eql(256);
+		cachedSource.size().should.be.eql(256);
+	});
+
 	it("should return the correct size for text files", function() {
 		var source = new OriginalSource("TestTestTest", "file.js");
 		var cachedSource = new CachedSource(source);
 
+		cachedSource.size().should.be.eql(12);
+		cachedSource.size().should.be.eql(12);
+	});
+
+	it("should return the correct size for cached text files", function() {
+		var source = new OriginalSource("TestTestTest", "file.js");
+		var cachedSource = new CachedSource(source);
+
+		cachedSource.source();
 		cachedSource.size().should.be.eql(12);
 		cachedSource.size().should.be.eql(12);
 	});

--- a/test/CachedSource.js
+++ b/test/CachedSource.js
@@ -1,0 +1,12 @@
+var should = require("should");
+var CachedSource = require("../lib/CachedSource");
+var OriginalSource = require('../lib/OriginalSource');
+
+describe("CachedSource", function() {
+	it("should return the correct size for binary files", function() {
+		var source = new OriginalSource(new ArrayBuffer(256), "file.wasm");
+		var cachedSource = new CachedSource(source);
+
+		cachedSource.size().should.be.eql(256);
+	});
+});

--- a/test/CachedSource.js
+++ b/test/CachedSource.js
@@ -36,4 +36,21 @@ describe("CachedSource", function() {
 		cachedSource.size().should.be.eql(12);
 		cachedSource.size().should.be.eql(12);
 	});
+
+	it("should return the correct size for unicode files", function() {
+		var source = new OriginalSource("😋", "file.js");
+		var cachedSource = new CachedSource(source);
+
+		cachedSource.size().should.be.eql(4);
+		cachedSource.size().should.be.eql(4);
+	});
+
+	it("should return the correct size for cached unicode files", function() {
+		var source = new OriginalSource("😋", "file.js");
+		var cachedSource = new CachedSource(source);
+
+		cachedSource.source();
+		cachedSource.size().should.be.eql(4);
+		cachedSource.size().should.be.eql(4);
+	});
 });

--- a/test/OriginalSource.js
+++ b/test/OriginalSource.js
@@ -61,4 +61,9 @@ describe("OriginalSource", function() {
 		var source = new OriginalSource(new ArrayBuffer(256), "file.wasm");
 		source.size().should.be.eql(256);
 	});
+
+	it("should return the correct size for unicode files", function() {
+		var source = new OriginalSource("😋", "file.js");
+		source.size().should.be.eql(4);
+	});
 });

--- a/test/OriginalSource.js
+++ b/test/OriginalSource.js
@@ -56,4 +56,9 @@ describe("OriginalSource", function() {
 
 		resultMap.mappings.should.be.eql("AAAA;AACA;AACA");
 	});
+
+	it("should return the correct size for binary files", function() {
+		var source = new OriginalSource(new ArrayBuffer(256), "file.wasm");
+		source.size().should.be.eql(256);
+	});
 });


### PR DESCRIPTION
This solves the same problem as #38 but includes both, `CachedSource.js` and `Source.js`.
It also adds a test for binary files.

PS: Fixes a linting error in `ReplaceSource.js`.

Fixes gajus/write-file-webpack-plugin#21
