### PR TITLE
Don't call size() or source() functions on child if child is undefined

### DIFF
--- a/lib/ConcatSource.js
+++ b/lib/ConcatSource.js
@@ -39,7 +39,7 @@ class ConcatSource extends Source {
 		const children = this.children;
 		for(let i = 0; i < children.length; i++) {
 			const child = children[i];
-			source += typeof child === "string" ? child : child.source();
+			source += typeof child === "string" ? child : (typeof child === 'undefined' ? '' : child.source());
 		}
 		return source;
 	}
@@ -49,7 +49,7 @@ class ConcatSource extends Source {
 		const children = this.children;
 		for(let i = 0; i < children.length; i++) {
 			const child = children[i];
-			size += typeof child === "string" ? child.length : child.size();
+			size += typeof child === "string" ? child.length : (typeof child === 'undefined' ? 0 : child.size());
 		}
 		return size;
 	}


### PR DESCRIPTION
When used in combination with webpack-dev-server, during a hot
reload, I've encountered an error "Cannot read property size of
undefined."

Doing a check to make sure that the child is defined in the size and
source methods of ConcatSource solves this issue for me.