### PR TITLE
split code into more tokens to fix sourcemap-validator warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The `options` object can contain the following keys:
 
 ``` js
 Source.prototype.sourceAndMap(options: Object) -> {
-	code: String,
+	source: String,
 	map: Object
 }
 ```
@@ -181,7 +181,7 @@ new ConcatSource(
 ConcatSource.prototype.add(item: Source | String)
 ```
 
-Adds an item to the source.	
+Adds an item to the source.
 
 ## `ReplaceSource`
 

--- a/lib/OriginalSource.js
+++ b/lib/OriginalSource.js
@@ -9,10 +9,10 @@ var SourceMapConsumer = require("source-map").SourceMapConsumer;
 var SourceListMap = require("source-list-map").SourceListMap;
 var Source = require("./Source");
 
-var SPLIT_REGEX = /(?!$)[^\n\r;{}]*[\n\r;{}]*/g;
+var SPLIT_REGEX = /([^\d\w]+)/g;
 
 function _splitCode(code) {
-	return code.match(SPLIT_REGEX) || [];
+	return code.split(SPLIT_REGEX);
 }
 
 class OriginalSource extends Source {
@@ -41,10 +41,6 @@ class OriginalSource extends Source {
 				}
 				return new SourceNode(null, null, null,
 					_splitCode(line + (idx != lines.length - 1 ? "\n" : "")).map(function(item) {
-						if(/^\s*$/.test(item)) {
-							pos += item.length;
-							return item;
-						}
 						var res = new SourceNode(idx + 1, pos, name, item);
 						pos += item.length;
 						return res;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "js-beautify": "^1.5.10",
     "mocha": "^3.4.2",
     "should": "^11.2.1",
-    "sourcemap-validator": "^1.1.0"
+    "sourcemap-validator": "^1.1.1"
   },
   "files": [
     "lib/"

--- a/test/ConcatSource.js
+++ b/test/ConcatSource.js
@@ -45,7 +45,7 @@ describe("ConcatSource", function() {
 		var expectedMap2 = {
 			version: 3,
 			file: "x",
-			mappings: ";AAAA;AACA;ACDA",
+			mappings: ";AAAA,OAAO,CAAC,GAAG,EAAE,IAAI;AACjB,OAAO,CAAC,GAAG,EAAE,KAAK;ACDlB,MAAM",
 			names: [],
 			sources: [
 				"console.js",

--- a/test/OriginalSource.js
+++ b/test/OriginalSource.js
@@ -68,7 +68,7 @@ describe("OriginalSource", function() {
 		source.size().should.be.eql(4);
 	});
 
-	it.only("pass sourcemap-validator checks", function() {
+	it("pass sourcemap-validator checks", function() {
 		var source = new OriginalSource(" \tvar installedModules = {};\n", "file.js");
 		var resultText = source.source();
 		var resultMap = source.sourceAndMap({

--- a/test/OriginalSource.js
+++ b/test/OriginalSource.js
@@ -1,4 +1,5 @@
 var should = require("should");
+var validate = require('sourcemap-validator');
 var OriginalSource = require("../lib/OriginalSource");
 
 describe("OriginalSource", function() {
@@ -21,7 +22,7 @@ describe("OriginalSource", function() {
 		resultListMap.map.sources.should.be.eql(resultMap.map.sources);
 		resultMap.map.sourcesContent.should.be.eql(["Line1\n\nLine3\n"]);
 		resultListMap.map.sourcesContent.should.be.eql(resultMap.map.sourcesContent);
-		resultMap.map.mappings.should.be.eql("AAAA;;AAEA");
+		resultMap.map.mappings.should.be.eql("AAAA,KAAK;AACL;AACA,KAAK");
 		resultListMap.map.mappings.should.be.eql("AAAA;AACA;AACA;");
 	});
 
@@ -65,5 +66,19 @@ describe("OriginalSource", function() {
 	it("should return the correct size for unicode files", function() {
 		var source = new OriginalSource("😋", "file.js");
 		source.size().should.be.eql(4);
+	});
+
+	it.only("pass sourcemap-validator checks", function() {
+		var source = new OriginalSource(" \tvar installedModules = {};\n", "file.js");
+		var resultText = source.source();
+		var resultMap = source.sourceAndMap({
+			columns: true
+		}).map;
+		var resultListMap = source.sourceAndMap({
+			columns: false
+		}).map;
+
+		validate(resultText, JSON.stringify(resultMap));
+		validate(resultText, JSON.stringify(resultListMap));
 	});
 });

--- a/test/PrefixSource.js
+++ b/test/PrefixSource.js
@@ -40,7 +40,7 @@ describe("PrefixSource", function() {
 		var expectedMap2 = {
 			version: 3,
 			file: "x",
-			mappings: "AAAA,qBAAoB;AACpB",
+			mappings: "AAAA,QAAO,CAAC,GAAG,EAAE,IAAI,GAAG,OAAO,CAAC,GAAG,EAAE,KAAK;AACtC,QAAO,CAAC,GAAG,EAAE,MAAM",
 			names: [],
 			sources: [
 				"console.js"

--- a/test/ReplaceSource.js
+++ b/test/ReplaceSource.js
@@ -45,7 +45,7 @@ describe("ReplaceSource", function() {
 		resultListMap.map.version.should.be.eql(resultMap.map.version);
 		resultListMap.map.sources.should.be.eql(resultMap.map.sources);
 		resultListMap.map.sourcesContent.should.be.eql(resultMap.map.sourcesContent);
-		resultMap.map.mappings.should.be.eql("AAAA,CAAC,EAAI,KAAE,IAAC;AACR,CAAC;AAAA;AAAA;AAID,IAAI,CACJ");
+		resultMap.map.mappings.should.be.eql("AAAA,CAAC,EAAI,IAAC,CAAC,IAAC,GAAG;AACX,CAAC;AAAA;AAAA;AAID,IAAI,CACJ");
 		resultListMap.map.mappings.should.be.eql("AAAA;AACA;AAAA;AAAA;AAIA,KACA");
 	});
 
@@ -74,7 +74,7 @@ describe("ReplaceSource", function() {
 		resultListMap.map.version.should.be.eql(resultMap.map.version);
 		resultListMap.map.sources.should.be.eql(resultMap.map.sources);
 		resultListMap.map.sourcesContent.should.be.eql(resultMap.map.sourcesContent);
-		resultMap.map.mappings.should.be.eql("AAAA,WAAE,GACE");
+		resultMap.map.mappings.should.be.eql("AAAA,WAAE,GACE,CAAC");
 		resultListMap.map.mappings.should.be.eql("AAAA,cACA");
 	});
 
@@ -99,7 +99,7 @@ describe("ReplaceSource", function() {
 		resultListMap.map.version.should.be.eql(resultMap.map.version);
 		resultListMap.map.sources.should.be.eql(resultMap.map.sources);
 		resultListMap.map.sourcesContent.should.be.eql(resultMap.map.sourcesContent);
-		resultMap.map.mappings.should.be.eql("AAAA;AAAA;AAAA");
+		resultMap.map.mappings.should.be.eql("AAAA;AAAA;AAAA,IAAI,CAAC");
 		resultListMap.map.mappings.should.be.eql("AAAA;AAAA;AAAA");
 	});
 
@@ -127,7 +127,7 @@ describe("ReplaceSource", function() {
 		resultListMap.map.version.should.be.eql(resultMap.map.version);
 		resultListMap.map.sources.should.be.eql(resultMap.map.sources);
 		resultListMap.map.sourcesContent.should.be.eql(resultMap.map.sourcesContent);
-		resultMap.map.mappings.should.be.eql("AAAA;AAAA,KAAM;AACN");
+		resultMap.map.mappings.should.be.eql("AAAA;AAAA,KAAM;AACN,IAAI,CAAC");
 		resultListMap.map.mappings.should.be.eql("AAAA;AAAA;AACA");
 	});
 
@@ -152,7 +152,7 @@ describe("ReplaceSource", function() {
 		resultListMap.map.version.should.be.eql(resultMap.map.version);
 		resultListMap.map.sources.should.be.eql(resultMap.map.sources);
 		resultListMap.map.sourcesContent.should.be.eql(resultMap.map.sourcesContent);
-		resultMap.map.mappings.should.be.eql("AAAA");
+		resultMap.map.mappings.should.be.eql("AAAA,IAAI,CAAC,CAAC");
 		resultListMap.map.mappings.should.be.eql("AAAA;;");
 	});
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1036,14 +1036,6 @@ lodash._baseassign@^3.0.0:
     lodash._basecopy "^3.0.0"
     lodash.keys "^3.0.0"
 
-lodash._basebind@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash._basebind/-/lodash._basebind-2.3.0.tgz#2b5bc452a0e106143b21869f233bdb587417d248"
-  dependencies:
-    lodash._basecreate "~2.3.0"
-    lodash._setbinddata "~2.3.0"
-    lodash.isobject "~2.3.0"
-
 lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
@@ -1052,105 +1044,18 @@ lodash._basecreate@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
 
-lodash._basecreate@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-2.3.0.tgz#9b88a86a4dcff7b7f3c61d83a2fcfc0671ec9de0"
-  dependencies:
-    lodash._renative "~2.3.0"
-    lodash.isobject "~2.3.0"
-    lodash.noop "~2.3.0"
-
-lodash._basecreatecallback@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash._basecreatecallback/-/lodash._basecreatecallback-2.3.0.tgz#37b2ab17591a339e988db3259fcd46019d7ac362"
-  dependencies:
-    lodash._setbinddata "~2.3.0"
-    lodash.bind "~2.3.0"
-    lodash.identity "~2.3.0"
-    lodash.support "~2.3.0"
-
-lodash._basecreatewrapper@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.3.0.tgz#aa0c61ad96044c3933376131483a9759c3651247"
-  dependencies:
-    lodash._basecreate "~2.3.0"
-    lodash._setbinddata "~2.3.0"
-    lodash._slice "~2.3.0"
-    lodash.isobject "~2.3.0"
-
-lodash._createwrapper@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash._createwrapper/-/lodash._createwrapper-2.3.0.tgz#d1aae1102dadf440e8e06fc133a6edd7fe146075"
-  dependencies:
-    lodash._basebind "~2.3.0"
-    lodash._basecreatewrapper "~2.3.0"
-    lodash.isfunction "~2.3.0"
-
-lodash._escapehtmlchar@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.3.0.tgz#d03da6bd82eedf38dc0a5b503d740ecd0e894592"
-  dependencies:
-    lodash._htmlescapes "~2.3.0"
-
-lodash._escapestringchar@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash._escapestringchar/-/lodash._escapestringchar-2.3.0.tgz#cce73ae60fc6da55d2bf8a0679c23ca2bab149fc"
-
 lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-
-lodash._htmlescapes@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash._htmlescapes/-/lodash._htmlescapes-2.3.0.tgz#1ca98863cadf1fa1d82c84f35f31e40556a04f3a"
 
 lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
 
-lodash._objecttypes@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash._objecttypes/-/lodash._objecttypes-2.3.0.tgz#6a3ea3987dd6eeb8021b2d5c9c303549cc2bae1e"
-
-lodash._reinterpolate@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-2.3.0.tgz#03ee9d85c0e55cbd590d71608a295bdda51128ec"
-
-lodash._renative@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash._renative/-/lodash._renative-2.3.0.tgz#77d8edd4ced26dd5971f9e15a5f772e4e317fbd3"
-
-lodash._reunescapedhtml@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.3.0.tgz#db920b55ac7f3ff825939aceb9ba2c231713d24d"
-  dependencies:
-    lodash._htmlescapes "~2.3.0"
-    lodash.keys "~2.3.0"
-
-lodash._setbinddata@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash._setbinddata/-/lodash._setbinddata-2.3.0.tgz#e5610490acd13277d59858d95b5f2727f1508f04"
-  dependencies:
-    lodash._renative "~2.3.0"
-    lodash.noop "~2.3.0"
-
-lodash._shimkeys@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash._shimkeys/-/lodash._shimkeys-2.3.0.tgz#611f93149e3e6c721096b48769ef29537ada8ba9"
-  dependencies:
-    lodash._objecttypes "~2.3.0"
-
-lodash._slice@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash._slice/-/lodash._slice-2.3.0.tgz#147198132859972e4680ca29a5992c855669aa5c"
-
-lodash.bind@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-2.3.0.tgz#c2a8e18b68e5ecc152e2b168266116fea5b016cc"
-  dependencies:
-    lodash._createwrapper "~2.3.0"
-    lodash._renative "~2.3.0"
-    lodash._slice "~2.3.0"
+lodash._reinterpolate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
+  integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
 lodash.create@3.1.1:
   version "3.1.1"
@@ -1160,39 +1065,10 @@ lodash.create@3.1.1:
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
-lodash.defaults@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-2.3.0.tgz#a832b001f138f3bb9721c2819a2a7cc5ae21ed25"
-  dependencies:
-    lodash._objecttypes "~2.3.0"
-    lodash.keys "~2.3.0"
-
-lodash.escape@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-2.3.0.tgz#844c38c58f844e1362ebe96726159b62cf5f2a58"
-  dependencies:
-    lodash._escapehtmlchar "~2.3.0"
-    lodash._reunescapedhtml "~2.3.0"
-    lodash.keys "~2.3.0"
-
-lodash.foreach@~2.3.x:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-2.3.0.tgz#083404c91e846ee77245fdf9d76519c68b2af168"
-  dependencies:
-    lodash._basecreatecallback "~2.3.0"
-    lodash.forown "~2.3.0"
-
-lodash.forown@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.forown/-/lodash.forown-2.3.0.tgz#24fb4aaf800d45fc2dc60bfec3ce04c836a3ad7f"
-  dependencies:
-    lodash._basecreatecallback "~2.3.0"
-    lodash._objecttypes "~2.3.0"
-    lodash.keys "~2.3.0"
-
-lodash.identity@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.identity/-/lodash.identity-2.3.0.tgz#6b01a210c9485355c2a913b48b6711219a173ded"
+lodash.foreach@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+  integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
@@ -1202,16 +1078,6 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
-lodash.isfunction@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-2.3.0.tgz#6b2973e47a647cf12e70d676aea13643706e5267"
-
-lodash.isobject@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-2.3.0.tgz#2e16d3fc583da9831968953f2d8e6d73434f6799"
-  dependencies:
-    lodash._objecttypes "~2.3.0"
-
 lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
@@ -1220,48 +1086,20 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash.keys@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-2.3.0.tgz#b350f4f92caa9f45a4a2ecf018454cf2f28ae253"
+lodash.template@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
+  integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
   dependencies:
-    lodash._renative "~2.3.0"
-    lodash._shimkeys "~2.3.0"
-    lodash.isobject "~2.3.0"
+    lodash._reinterpolate "^3.0.0"
+    lodash.templatesettings "^4.0.0"
 
-lodash.noop@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.noop/-/lodash.noop-2.3.0.tgz#3059d628d51bbf937cd2a0b6fc3a7f212a669c2c"
-
-lodash.support@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.support/-/lodash.support-2.3.0.tgz#7eaf038af4f0d6aab776b44aa6dcfc80334c9bfd"
+lodash.templatesettings@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz#e481310f049d3cf6d47e912ad09313b154f0fb33"
+  integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
   dependencies:
-    lodash._renative "~2.3.0"
-
-lodash.template@~2.3.x:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-2.3.0.tgz#4e3e29c433b4cfea675ec835e6f12391c61fd22b"
-  dependencies:
-    lodash._escapestringchar "~2.3.0"
-    lodash._reinterpolate "~2.3.0"
-    lodash.defaults "~2.3.0"
-    lodash.escape "~2.3.0"
-    lodash.keys "~2.3.0"
-    lodash.templatesettings "~2.3.0"
-    lodash.values "~2.3.0"
-
-lodash.templatesettings@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-2.3.0.tgz#303d132c342710040d5a18efaa2d572fd03f8cdc"
-  dependencies:
-    lodash._reinterpolate "~2.3.0"
-    lodash.escape "~2.3.0"
-
-lodash.values@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-2.3.0.tgz#ca96fbe60a20b0b0ec2ba2ba5fc6a765bd14a3ba"
-  dependencies:
-    lodash.keys "~2.3.0"
+    lodash._reinterpolate "^3.0.0"
 
 lodash@^4.0.0, lodash@^4.3.0:
   version "4.17.4"
@@ -1702,13 +1540,14 @@ source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
-sourcemap-validator@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/sourcemap-validator/-/sourcemap-validator-1.1.0.tgz#00454547d1682186e1498a7208e022e8dfa8738f"
+sourcemap-validator@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/sourcemap-validator/-/sourcemap-validator-1.1.1.tgz#3d7d8a399ccab09c1fedc510d65436e25b1c386b"
+  integrity sha512-pq6y03Vs6HUaKo9bE0aLoksAcpeOo9HZd7I8pI6O480W/zxNZ9U32GfzgtPP0Pgc/K1JHna569nAbOk3X8/Qtw==
   dependencies:
     jsesc "~0.3.x"
-    lodash.foreach "~2.3.x"
-    lodash.template "~2.3.x"
+    lodash.foreach "^4.5.0"
+    lodash.template "^4.5.0"
     source-map "~0.1.x"
 
 split@~0.2.10:


### PR DESCRIPTION
Fixes https://github.com/webpack/webpack/issues/8302

Add more nodes to create a more granular identity source map. This allows for better source maps when other consumers process what webpack creates (I've been using the terser plugin).

Previous splitting resulted in this (this is post-terser):
![image](https://user-images.githubusercontent.com/4071474/61928803-6d61e780-af2e-11e9-8386-ccfba81bd140.png)

note that all mappings map to column 0 for every line.

Now:

![image](https://user-images.githubusercontent.com/4071474/61928828-87032f00-af2e-11e9-826c-5d0a99e2ad97.png)

I also added a test that did a (too simple) check w/ `sourcemap-validator`. It passes even w/o these changes - I didn't spend any time thinking about how to create a test case that would mimic what terser was doing. Perhaps someone could help with that?