### PR TITLE
drop support for node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
       node_js: "8"
     - os: linux
       node_js: "6"
-    - os: linux
-      node_js: "4.3"
     - os: osx
       node_js: "8"
   allow_failures:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.3.0",
   "description": "Source code handling classes for webpack",
   "main": "./lib/index.js",
+  "engines": {
+    "node": ">=6.11.5"
+  },
   "scripts": {
     "pretest": "npm run lint && npm run beautify-lint",
     "test": "mocha --full-trace --check-leaks",


### PR DESCRIPTION
according to webpack's package.json, the minumum supported node is `6.11.5`

removing node 4 from travis, and specifying min version in `webpack-sources` package.json.