### PR TITLE
Performance improvements

### DIFF
--- a/lib/CachedSource.js
+++ b/lib/CachedSource.js
@@ -7,18 +7,54 @@
 const Source = require("./Source");
 
 class CachedSource extends Source {
-	constructor(source) {
+	constructor(source, cachedData) {
 		super();
 		this._source = source;
+		this._cachedSourceType = cachedData ? cachedData.source : undefined;
 		this._cachedSource = undefined;
-		this._cachedBuffer = undefined;
-		this._cachedSize = undefined;
-		this._cachedMaps = {};
+		this._cachedBuffer = cachedData ? cachedData.buffer : undefined;
+		this._cachedSize = cachedData ? cachedData.size : undefined;
+		this._cachedMaps = cachedData ? cachedData.maps : new Map();
 	}
 
+	getCachedData() {
+		// We don't want to cache strings
+		// So if we have a caches sources
+		// create a buffer from it and only store
+		// if it was a Buffer or string
+		if (this._cachedSource) {
+			this.buffer();
+		}
+		return {
+			buffer: this._cachedBuffer,
+			source:
+				this._cachedSourceType !== undefined
+					? this._cachedSourceType
+					: typeof this._cachedSource === "string"
+					? true
+					: Buffer.isBuffer(this._cachedSource)
+					? false
+					: undefined,
+			size: this._cachedSize,
+			maps: this._cachedMaps
+		};
+	}
+
+	original() {
+		return this._source;
+	}
+
+	_ensureSource() {}
+
 	source() {
-		if (typeof this._cachedSource !== "undefined") return this._cachedSource;
-		return (this._cachedSource = this._source.source());
+		if (this._cachedSource !== undefined) return this._cachedSource;
+		if (this._cachedBuffer && this._cachedSourceType !== undefined) {
+			return (this._cachedSource = this._cachedSourceType
+				? this._cachedBuffer.toString("utf-8")
+				: this._cachedBuffer);
+		} else {
+			return (this._cachedSource = this._source.source());
+		}
 	}
 
 	buffer() {
@@ -44,22 +80,25 @@ class CachedSource extends Source {
 		if (typeof this._cachedSource !== "undefined") {
 			return (this._cachedSize = Buffer.byteLength(this._cachedSource));
 		}
+		if (typeof this._cachedBuffer !== "undefined") {
+			return (this._cachedSize = this._cachedBuffer.length);
+		}
 		return (this._cachedSize = this._source.size());
 	}
 
 	sourceAndMap(options) {
 		const key = options ? JSON.stringify(options) : "{}";
-		if (typeof this._cachedSource !== "undefined" && key in this._cachedMaps)
+		let map = this._cachedMaps.get(key);
+		if (typeof this._cachedSource !== "undefined") {
+			if (map === undefined) {
+				map = this._source.map(options);
+				this._cachedMaps.set(key, map);
+			}
 			return {
 				source: this._cachedSource,
-				map: this._cachedMaps[key]
+				map
 			};
-		else if (typeof this._cachedSource !== "undefined") {
-			return {
-				source: this._cachedSource,
-				map: (this._cachedMaps[key] = this._source.map(options))
-			};
-		} else if (key in this._cachedMaps) {
+		} else if (map !== undefined) {
 			return {
 				source: (this._cachedSource = this._source.source()),
 				map: this._cachedMaps[key]
@@ -67,17 +106,18 @@ class CachedSource extends Source {
 		}
 		const result = this._source.sourceAndMap(options);
 		this._cachedSource = result.source;
-		this._cachedMaps[key] = result.map;
-		return {
-			source: this._cachedSource,
-			map: this._cachedMaps[key]
-		};
+		this._cachedMaps.set(key, result.map);
+		return result;
 	}
 
 	map(options) {
 		const key = options ? JSON.stringify(options) : "{}";
-		if (key in this._cachedMaps) return this._cachedMaps[key];
-		return (this._cachedMaps[key] = this._source.map());
+		let map = this._cachedMaps.get(key);
+		if (map === undefined) {
+			map = this._source.map(options);
+			this._cachedMaps.set(key, map);
+		}
+		return map;
 	}
 
 	updateHash(hash) {

--- a/lib/ConcatSource.js
+++ b/lib/ConcatSource.js
@@ -5,98 +5,84 @@
 "use strict";
 
 const Source = require("./Source");
+const RawSource = require("./RawSource");
 const { SourceNode, SourceMapConsumer } = require("source-map");
 const { SourceListMap, fromStringWithSourceMap } = require("source-list-map");
 const { getSourceAndMap, getMap } = require("./helpers");
 
+const stringsAsRawSources = new WeakSet();
+
 class ConcatSource extends Source {
 	constructor() {
 		super();
-		this.children = [];
+		this._children = [];
 		for (let i = 0; i < arguments.length; i++) {
 			const item = arguments[i];
 			if (item instanceof ConcatSource) {
-				const children = item.children;
-				for (let j = 0; j < children.length; j++) {
-					this.children.push(children[j]);
+				for (const child of item._children) {
+					this._children.push(child);
 				}
 			} else {
-				this.children.push(item);
+				this._children.push(item);
 			}
 		}
+		this._isOptimized = arguments.length === 0;
+	}
+
+	getChildren() {
+		if (!this._isOptimized) this._optimize();
+		return this._children;
 	}
 
 	add(item) {
 		if (item instanceof ConcatSource) {
-			const children = item.children;
-			for (let j = 0; j < children.length; j++) {
-				this.children.push(children[j]);
+			for (const child of item._children) {
+				this._children.push(child);
 			}
 		} else {
-			this.children.push(item);
+			this._children.push(item);
+		}
+		this._isOptimized = false;
+	}
+
+	addAllSkipOptimizing(items) {
+		for (const item of items) {
+			this._children.push(item);
 		}
 	}
 
 	buffer() {
+		if (!this._isOptimized) this._optimize();
 		const buffers = [];
-		let currentString = undefined;
-		const children = this.children;
-		for (let i = 0; i < children.length; i++) {
-			const child = children[i];
-			if (typeof child === "string") {
-				if (currentString === undefined) {
-					currentString = child;
-				} else {
-					currentString += child;
-				}
-			} else if (typeof child.buffer === "function") {
-				if (currentString !== undefined) {
-					buffers.push(Buffer.from(currentString, "utf-8"));
-					currentString = undefined;
-				}
+		for (const child of this._children) {
+			if (typeof child.buffer === "function") {
 				buffers.push(child.buffer());
 			} else {
 				const bufferOrString = child.source();
 				if (Buffer.isBuffer(bufferOrString)) {
-					if (currentString !== undefined) {
-						buffers.push(Buffer.from(currentString, "utf-8"));
-						currentString = undefined;
-					}
 					buffers.push(bufferOrString);
 				} else {
-					if (currentString === undefined) {
-						currentString = bufferOrString;
-					} else {
-						currentString += bufferOrString;
-					}
+					buffers.push(Buffer.from(bufferOrString, "utf-8"));
 				}
 			}
-		}
-		if (currentString !== undefined) {
-			buffers.push(Buffer.from(currentString, "utf-8"));
 		}
 		return Buffer.concat(buffers);
 	}
 
 	source() {
+		if (!this._isOptimized) this._optimize();
 		let source = "";
-		const children = this.children;
-		for (let i = 0; i < children.length; i++) {
-			const child = children[i];
-			source += typeof child === "string" ? child : child.source();
+		for (const child of this._children) {
+			source += child.source();
 		}
 		return source;
 	}
 
 	size() {
+		if (!this._isOptimized) this._optimize();
 		let size = 0;
-		const children = this.children;
-		for (let i = 0; i < children.length; i++) {
-			const child = children[i];
-			size +=
-				typeof child === "string"
-					? Buffer.byteLength(child, "utf-8")
-					: child.size();
+		for (const child of this._children) {
+			size += child.size();
 		}
 		return size;
 	}
@@ -110,12 +96,12 @@ class ConcatSource extends Source {
 	}
 
 	node(options) {
+		if (!this._isOptimized) this._optimize();
 		const node = new SourceNode(
 			null,
 			null,
 			null,
-			this.children.map(function(item) {
-				if (typeof item === "string") return item;
+			this._children.map(function(item) {
 				if (typeof item.node === "function") return item.node(options);
 				const sourceAndMap = item.sourceAndMap(options);
 				if (sourceAndMap.map) {
@@ -132,10 +118,9 @@ class ConcatSource extends Source {
 	}
 
 	listMap(options) {
+		if (!this._isOptimized) this._optimize();
 		const map = new SourceListMap();
-		const children = this.children;
-		for (let i = 0; i < children.length; i++) {
-			const item = children[i];
+		for (const item of this._children) {
 			if (typeof item === "string") {
 				map.add(item);
 			} else if (typeof item.listMap === "function") {
@@ -155,13 +140,89 @@ class ConcatSource extends Source {
 	}
 
 	updateHash(hash) {
+		if (!this._isOptimized) this._optimize();
 		hash.update("ConcatSource");
-		const children = this.children;
-		for (let i = 0; i < children.length; i++) {
-			const item = children[i];
-			if (typeof item === "string") hash.update(item);
-			else item.updateHash(hash);
+		for (const item of this._children) {
+			item.updateHash(hash);
 		}
+	}
+
+	_optimize() {
+		const newChildren = [];
+		let currentString = undefined;
+		let currentRawSources = undefined;
+		const addStringToRawSources = string => {
+			if (currentRawSources === undefined) {
+				currentRawSources = string;
+			} else if (Array.isArray(currentRawSources)) {
+				currentRawSources.push(string);
+			} else {
+				currentRawSources = [
+					typeof currentRawSources === "string"
+						? currentRawSources
+						: currentRawSources.source(),
+					string
+				];
+			}
+		};
+		const addSourceToRawSources = source => {
+			if (currentRawSources === undefined) {
+				currentRawSources = source;
+			} else if (Array.isArray(currentRawSources)) {
+				currentRawSources.push(source.source());
+			} else {
+				currentRawSources = [
+					typeof currentRawSources === "string"
+						? currentRawSources
+						: currentRawSources.source(),
+					source.source()
+				];
+			}
+		};
+		const mergeRawSources = () => {
+			if (Array.isArray(currentRawSources)) {
+				const rawSource = new RawSource(currentRawSources.join(""));
+				stringsAsRawSources.add(rawSource);
+				newChildren.push(rawSource);
+			} else if (typeof currentRawSources === "string") {
+				const rawSource = new RawSource(currentRawSources);
+				stringsAsRawSources.add(rawSource);
+				newChildren.push(rawSource);
+			} else {
+				newChildren.push(currentRawSources);
+			}
+		};
+		for (const child of this._children) {
+			if (typeof child === "string") {
+				if (currentString === undefined) {
+					currentString = child;
+				} else {
+					currentString += child;
+				}
+			} else {
+				if (currentString !== undefined) {
+					addStringToRawSources(currentString);
+					currentString = undefined;
+				}
+				if (stringsAsRawSources.has(child)) {
+					addSourceToRawSources(child);
+				} else {
+					if (currentRawSources !== undefined) {
+						mergeRawSources();
+						currentRawSources = undefined;
+					}
+					newChildren.push(child);
+				}
+			}
+		}
+		if (currentString !== undefined) {
+			addStringToRawSources(currentString);
+		}
+		if (currentRawSources !== undefined) {
+			mergeRawSources();
+		}
+		this._children = newChildren;
+		this._isOptimized = true;
 	}
 }
 

--- a/lib/OriginalSource.js
+++ b/lib/OriginalSource.js
@@ -18,12 +18,28 @@ function _splitCode(code) {
 class OriginalSource extends Source {
 	constructor(value, name) {
 		super();
-		this._value = value;
+		const isBuffer = Buffer.isBuffer(value);
+		this._value = isBuffer ? undefined : value;
+		this._valueAsBuffer = isBuffer ? value : undefined;
 		this._name = name;
 	}
 
+	getName() {
+		return this._name;
+	}
+
 	source() {
+		if (this._value === undefined) {
+			this._value = this._valueAsBuffer.toString("utf-8");
+		}
 		return this._value;
+	}
+
+	buffer() {
+		if (this._valueAsBuffer === undefined) {
+			this._valueAsBuffer = Buffer.from(this._value, "utf-8");
+		}
+		return this._valueAsBuffer;
 	}
 
 	map(options) {
@@ -35,6 +51,9 @@ class OriginalSource extends Source {
 	}
 
 	node(options) {
+		if (this._value === undefined) {
+			this._value = this._valueAsBuffer.toString("utf-8");
+		}
 		const value = this._value;
 		const name = this._name;
 		const lines = value.split("\n");
@@ -71,12 +90,18 @@ class OriginalSource extends Source {
 	}
 
 	listMap(options) {
+		if (this._value === undefined) {
+			this._value = this._valueAsBuffer.toString("utf-8");
+		}
 		return new SourceListMap(this._value, this._name, this._value);
 	}
 
 	updateHash(hash) {
+		if (this._valueAsBuffer === undefined) {
+			this._valueAsBuffer = Buffer.from(this._value, "utf-8");
+		}
 		hash.update("OriginalSource");
-		hash.update(this._value);
+		hash.update(this._valueAsBuffer);
 		hash.update(this._name || "");
 	}
 }

--- a/lib/PrefixSource.js
+++ b/lib/PrefixSource.js
@@ -5,6 +5,7 @@
 "use strict";
 
 const Source = require("./Source");
+const RawSource = require("./RawSource");
 const { SourceNode } = require("source-map");
 const { getSourceAndMap, getMap } = require("./helpers");
 
@@ -13,16 +14,28 @@ const REPLACE_REGEX = /\n(?=.|\s)/g;
 class PrefixSource extends Source {
 	constructor(prefix, source) {
 		super();
-		this._source = source;
+		this._source =
+			typeof source === "string" || Buffer.isBuffer(source)
+				? new RawSource(source, true)
+				: source;
 		this._prefix = prefix;
 	}
 
+	getPrefix() {
+		return this._prefix;
+	}
+
+	original() {
+		return this._source;
+	}
+
 	source() {
-		const node =
-			typeof this._source === "string" ? this._source : this._source.source();
+		const node = this._source.source();
 		const prefix = this._prefix;
 		return prefix + node.replace(REPLACE_REGEX, "\n" + prefix);
 	}
+
+	// TODO efficient buffer() implementation
 
 	map(options) {
 		return getMap(this, options);
@@ -81,8 +94,7 @@ class PrefixSource extends Source {
 
 	updateHash(hash) {
 		hash.update("PrefixSource");
-		if (typeof this._source === "string") hash.update(this._source);
-		else this._source.updateHash(hash);
+		this._source.updateHash(hash);
 		hash.update(this._prefix);
 	}
 }

--- a/lib/RawSource.js
+++ b/lib/RawSource.js
@@ -9,13 +9,33 @@ const { SourceNode } = require("source-map");
 const { SourceListMap } = require("source-list-map");
 
 class RawSource extends Source {
-	constructor(value) {
+	constructor(value, convertToString = false) {
 		super();
-		this._value = value;
+		const isBuffer = Buffer.isBuffer(value);
+		if (!isBuffer && typeof value !== "string") {
+			throw new TypeError("argument 'value' must be either string of Buffer");
+		}
+		this._valueIsBuffer = !convertToString && isBuffer;
+		this._value = convertToString && isBuffer ? undefined : value;
+		this._valueAsBuffer = isBuffer ? value : undefined;
+	}
+
+	isBuffer() {
+		return this._valueIsBuffer;
 	}
 
 	source() {
+		if (this._value === undefined) {
+			this._value = this._valueAsBuffer.toString("utf-8");
+		}
 		return this._value;
+	}
+
+	buffer() {
+		if (this._valueAsBuffer === undefined) {
+			this._valueAsBuffer = Buffer.from(this._value, "utf-8");
+		}
+		return this._valueAsBuffer;
 	}
 
 	map(options) {
@@ -23,16 +43,25 @@ class RawSource extends Source {
 	}
 
 	node(options) {
+		if (this._value === undefined) {
+			this._value = this._valueAsBuffer.toString("utf-8");
+		}
 		return new SourceNode(null, null, null, this._value);
 	}
 
 	listMap(options) {
+		if (this._value === undefined) {
+			this._value = this._valueAsBuffer.toString("utf-8");
+		}
 		return new SourceListMap(this._value);
 	}
 
 	updateHash(hash) {
+		if (this._valueAsBuffer === undefined) {
+			this._valueAsBuffer = Buffer.from(this._value, "utf-8");
+		}
 		hash.update("RawSource");
-		hash.update(this._value);
+		hash.update(this._valueAsBuffer);
 	}
 }
 

--- a/lib/ReplaceSource.js
+++ b/lib/ReplaceSource.js
@@ -28,6 +28,18 @@ class ReplaceSource extends Source {
 		this._isSorted = true;
 	}
 
+	getName() {
+		return this._name;
+	}
+
+	getReplacements() {
+		const replacements = Array.from(this._replacements);
+		replacements.sort((a, b) => {
+			return a.insertIndex - b.insertIndex;
+		});
+		return replacements;
+	}
+
 	replace(start, end, newValue, name) {
 		if (typeof newValue !== "string")
 			throw new Error(

--- a/lib/SizeOnlySource.js
+++ b/lib/SizeOnlySource.js
@@ -22,7 +22,11 @@ class SizeOnlySource extends Source {
 		return this._size;
 	}
 
-	source(options) {
+	source() {
+		throw this._error();
+	}
+
+	buffer() {
 		throw this._error();
 	}
 

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -16,7 +16,7 @@ class Source {
 	}
 
 	size() {
-		return Buffer.byteLength(this.source());
+		return this.buffer().length;
 	}
 
 	map(options) {

--- a/lib/SourceMapSource.js
+++ b/lib/SourceMapSource.js
@@ -20,72 +20,184 @@ class SourceMapSource extends Source {
 		removeOriginalSource
 	) {
 		super();
-		this._value = value;
+		const valueIsBuffer = Buffer.isBuffer(value);
+		this._valueAsString = valueIsBuffer ? undefined : value;
+		this._valueAsBuffer = valueIsBuffer ? value : undefined;
+
 		this._name = name;
-		this._sourceMap = sourceMap;
-		this._sourceMapObject = undefined;
-		this._sourceMapString = undefined;
-		this._originalSource = originalSource;
-		this._innerSourceMap = innerSourceMap;
-		this._innerSourceMapObject = undefined;
-		this._innerSourceMapString = undefined;
+
+		this._hasSourceMap = !!sourceMap;
+		const sourceMapIsBuffer = Buffer.isBuffer(sourceMap);
+		const sourceMapIsString = typeof sourceMap === "string";
+		this._sourceMapAsObject =
+			sourceMapIsBuffer || sourceMapIsString ? undefined : sourceMap;
+		this._sourceMapAsString = sourceMapIsString ? sourceMap : undefined;
+		this._sourceMapAsBuffer = sourceMapIsBuffer ? sourceMap : undefined;
+
+		this._hasOriginalSource = !!originalSource;
+		const originalSourceIsBuffer = Buffer.isBuffer(originalSource);
+		this._originalSourceAsString = originalSourceIsBuffer
+			? undefined
+			: originalSource;
+		this._originalSourceAsBuffer = originalSourceIsBuffer
+			? originalSource
+			: undefined;
+
+		this._hasInnerSourceMap = !!innerSourceMap;
+		const innerSourceMapIsBuffer = Buffer.isBuffer(innerSourceMap);
+		const innerSourceMapIsString = typeof innerSourceMap === "string";
+		this._innerSourceMapAsObject =
+			innerSourceMapIsBuffer || innerSourceMapIsString
+				? undefined
+				: innerSourceMap;
+		this._innerSourceMapAsString = innerSourceMapIsString
+			? innerSourceMap
+			: undefined;
+		this._innerSourceMapAsBuffer = innerSourceMapIsBuffer
+			? innerSourceMap
+			: undefined;
+
 		this._removeOriginalSource = removeOriginalSource;
 	}
 
+	_ensureValueBuffer() {
+		if (this._valueAsBuffer === undefined) {
+			this._valueAsBuffer = Buffer.from(this._valueAsString, "utf-8");
+		}
+	}
+
+	_ensureValueString() {
+		if (this._valueAsString === undefined) {
+			this._valueAsString = this._valueAsBuffer.toString("utf-8");
+		}
+	}
+
+	_ensureOriginalSourceBuffer() {
+		if (this._originalSourceAsBuffer === undefined && this._hasOriginalSource) {
+			this._originalSourceAsBuffer = Buffer.from(
+				this._originalSourceAsString,
+				"utf-8"
+			);
+		}
+	}
+
+	_ensureOriginalSourceString() {
+		if (this._originalSourceAsString === undefined && this._hasOriginalSource) {
+			this._originalSourceAsString = this._originalSourceAsBuffer.toString(
+				"utf-8"
+			);
+		}
+	}
+
+	_ensureInnerSourceMapObject() {
+		if (this._innerSourceMapAsObject === undefined && this._hasInnerSourceMap) {
+			this._ensureInnerSourceMapString();
+			this._innerSourceMapAsObject = JSON.parse(this._innerSourceMapAsString);
+		}
+	}
+
+	_ensureInnerSourceMapBuffer() {
+		if (this._innerSourceMapAsBuffer === undefined && this._hasInnerSourceMap) {
+			this._ensureInnerSourceMapString();
+			this._innerSourceMapAsBuffer = Buffer.from(
+				this._innerSourceMapAsString,
+				"utf-8"
+			);
+		}
+	}
+
+	_ensureInnerSourceMapString() {
+		if (this._innerSourceMapAsString === undefined && this._hasInnerSourceMap) {
+			if (this._innerSourceMapAsBuffer !== undefined) {
+				this._innerSourceMapAsString = this._innerSourceMapAsBuffer.toString(
+					"utf-8"
+				);
+			} else {
+				this._innerSourceMapAsString = JSON.stringify(
+					this._innerSourceMapAsObject
+				);
+			}
+		}
+	}
+
+	_ensureSourceMapObject() {
+		if (this._sourceMapAsObject === undefined) {
+			this._ensureSourceMapString();
+			this._sourceMapAsObject = JSON.parse(this._sourceMapAsString);
+		}
+	}
+
+	_ensureSourceMapBuffer() {
+		if (this._sourceMapAsBuffer === undefined) {
+			this._ensureSourceMapString();
+			this._sourceMapAsBuffer = Buffer.from(this._sourceMapAsString, "utf-8");
+		}
+	}
+
+	_ensureSourceMapString() {
+		if (this._sourceMapAsString === undefined) {
+			if (this._sourceMapAsBuffer !== undefined) {
+				this._sourceMapAsString = this._sourceMapAsBuffer.toString("utf-8");
+			} else {
+				this._sourceMapAsString = JSON.stringify(this._sourceMapAsObject);
+			}
+		}
+	}
+
+	getArgsAsBuffers() {
+		this._ensureValueBuffer();
+		this._ensureSourceMapBuffer();
+		this._ensureOriginalSourceBuffer();
+		this._ensureInnerSourceMapBuffer();
+		return [
+			this._valueAsBuffer,
+			this._name,
+			this._sourceMapAsBuffer,
+			this._originalSourceAsBuffer,
+			this._innerSourceMapAsBuffer,
+			this._removeOriginalSource
+		];
+	}
+
 	source() {
-		return this._value;
+		this._ensureValueString();
+		return this._valueAsString;
 	}
 
 	map(options) {
-		if (!this._innerSourceMap) {
-			return (
-				this._sourceMapObject ||
-				(this._sourceMapObject =
-					typeof this._sourceMap === "string"
-						? JSON.parse(this._sourceMap)
-						: this._sourceMap)
-			);
+		if (!this._hasInnerSourceMap) {
+			this._ensureSourceMapObject();
+			return this._sourceMapAsObject;
 		}
 		return getMap(this, options);
 	}
 
 	sourceAndMap(options) {
-		if (!this._innerSourceMap) {
+		if (!this._hasInnerSourceMap) {
+			this._ensureValueString();
+			this._ensureSourceMapObject();
 			return {
-				source: this._value,
-				map:
-					this._sourceMapObject ||
-					(this._sourceMapObject =
-						typeof this._sourceMap === "string"
-							? JSON.parse(this._sourceMap)
-							: this._sourceMap)
+				source: this._valueAsString,
+				map: this._sourceMapAsObject
 			};
 		}
 		return getSourceAndMap(this, options);
 	}
 
 	node(options) {
-		const sourceMap =
-			this._sourceMapObject ||
-			(this._sourceMapObject =
-				typeof this._sourceMap === "string"
-					? JSON.parse(this._sourceMap)
-					: this._sourceMap);
+		this._ensureValueString();
+		this._ensureSourceMapObject();
+		this._ensureOriginalSourceString();
 		let node = SourceNode.fromStringWithSourceMap(
-			this._value,
-			new SourceMapConsumer(sourceMap)
+			this._valueAsString,
+			new SourceMapConsumer(this._sourceMapAsObject)
 		);
-		node.setSourceContent(this._name, this._originalSource);
-		if (this._innerSourceMap) {
-			const innerSourceMap =
-				this._innerSourceMapObject ||
-				(this._innerSourceMapObject =
-					typeof this._innerSourceMap === "string"
-						? JSON.parse(this._innerSourceMap)
-						: this._innerSourceMap);
+		node.setSourceContent(this._name, this._originalSourceAsString);
+		if (this._hasInnerSourceMap) {
+			this._ensureInnerSourceMapObject();
 			node = applySourceMap(
 				node,
-				new SourceMapConsumer(innerSourceMap),
+				new SourceMapConsumer(this._innerSourceMapAsObject),
 				this._name,
 				this._removeOriginalSource
 			);
@@ -94,44 +206,40 @@ class SourceMapSource extends Source {
 	}
 
 	listMap(options) {
+		this._ensureValueString();
+		this._ensureSourceMapObject();
 		options = options || {};
 		if (options.module === false)
-			return new SourceListMap(this._value, this._name, this._value);
+			return new SourceListMap(
+				this._valueAsString,
+				this._name,
+				this._valueAsString
+			);
 
-		const sourceMap =
-			this._sourceMapObject ||
-			(this._sourceMapObject =
-				typeof this._sourceMap === "string"
-					? JSON.parse(this._sourceMap)
-					: this._sourceMap);
-		return fromStringWithSourceMap(this._value, sourceMap);
+		return fromStringWithSourceMap(
+			this._valueAsString,
+			this._sourceMapAsObject
+		);
 	}
 
 	updateHash(hash) {
+		this._ensureValueBuffer();
+		this._ensureSourceMapBuffer();
+		this._ensureOriginalSourceBuffer();
+		this._ensureInnerSourceMapBuffer();
+
 		hash.update("SourceMapSource");
 
-		hash.update(this._value);
+		hash.update(this._valueAsBuffer);
 
-		const sourceMap =
-			this._sourceMapString ||
-			(this._sourceMapString =
-				typeof this._sourceMap === "string"
-					? this._sourceMap
-					: JSON.stringify(this._sourceMap));
-		hash.update(sourceMap);
+		hash.update(this._sourceMapAsBuffer);
 
-		if (this._originalSource) {
-			hash.update(this._originalSource);
+		if (this._hasOriginalSource) {
+			hash.update(this._originalSourceAsBuffer);
 		}
 
-		if (this._innerSourceMap) {
-			const innerSourceMap =
-				this._innerSourceMapString ||
-				(this._innerSourceMapString =
-					typeof this._innerSourceMap === "string"
-						? this._innerSourceMap
-						: JSON.stringify(this._innerSourceMap));
-			hash.update(innerSourceMap);
+		if (this._hasInnerSourceMap) {
+			hash.update(this._innerSourceMapAsBuffer);
 		}
 
 		hash.update(this._removeOriginalSource ? "true" : "false");

--- a/test/CachedSource.js
+++ b/test/CachedSource.js
@@ -211,7 +211,7 @@ describe("CachedSource", function() {
 	});
 	it("should use binary source for buffer", function() {
 		var buffer = Buffer.from(new Array(256));
-		var source = new TrackedSource(new RawSource(buffer, "file.wasm"));
+		var source = new TrackedSource(new RawSource(buffer));
 		var cachedSource = new CachedSource(source);
 
 		cachedSource.sourceAndMap().source.should.be.equal(buffer);
@@ -234,7 +234,7 @@ describe("CachedSource", function() {
 	});
 	it("should use an old webpack-sources Source", function() {
 		var buffer = Buffer.from(new Array(256));
-		var source = new TrackedSource(new RawSource(buffer, "file.wasm"));
+		var source = new TrackedSource(new RawSource(buffer));
 		source.buffer = undefined;
 		var cachedSource = new CachedSource(source);
 
@@ -252,7 +252,7 @@ describe("CachedSource", function() {
 	});
 	it("should use an old webpack-sources Source", function() {
 		var string = "Hello World";
-		var source = new TrackedSource(new RawSource(string, "file.txt"));
+		var source = new TrackedSource(new RawSource(string));
 		source.buffer = undefined;
 		var cachedSource = new CachedSource(source);
 

--- a/test/SourceMapSource.js
+++ b/test/SourceMapSource.js
@@ -70,5 +70,20 @@ describe("SourceMapSource", function() {
 			sourcesContent: [innerSourceCode],
 			version: 3
 		});
+
+		var hash = require("crypto").createHash("sha256");
+		sourceMapSource1.updateHash(hash);
+		var digest = hash.digest("hex");
+		digest.should.be.eql(
+			"c46f63c0329381f89b8882d60964808e95380dbac726c343a765200355875147"
+		);
+
+		const clone = new SourceMapSource(...sourceMapSource1.getArgsAsBuffers());
+		clone.sourceAndMap().should.be.eql(sourceMapSource1.sourceAndMap());
+
+		var hash2 = require("crypto").createHash("sha256");
+		clone.updateHash(hash2);
+		var digest2 = hash2.digest("hex");
+		digest2.should.be.eql(digest);
 	});
 });


### PR DESCRIPTION
cache utf-8 conversion
allow keeping Buffer instead of string and only convert it lazily
expose everything needed for serialization as public methods
add optimization step to ConcatSource which converts strings to RawSources (which cache)