### PR TITLE
avoid strings in CachedSource `map()` cache

### DIFF
--- a/lib/CachedSource.js
+++ b/lib/CachedSource.js
@@ -6,6 +6,32 @@
 
 const Source = require("./Source");
 
+const mapToBufferedMap = map => {
+	const bufferedMap = Object.assign({}, map);
+	if (map.mappings) {
+		bufferedMap.mappings = Buffer.from(map.mappings, "utf-8");
+	}
+	if (map.sourcesContent) {
+		bufferedMap.sourcesContent = map.sourcesContent.map(
+			str => str && Buffer.from(str, "utf-8")
+		);
+	}
+	return bufferedMap;
+};
+
+const bufferedMapToMap = bufferedMap => {
+	const map = Object.assign({}, bufferedMap);
+	if (bufferedMap.mappings) {
+		map.mappings = bufferedMap.mappings.toString("utf-8");
+	}
+	if (bufferedMap.sourcesContent) {
+		map.sourcesContent = bufferedMap.sourcesContent.map(
+			buffer => buffer && buffer.toString("utf-8")
+		);
+	}
+	return map;
+};
+
 class CachedSource extends Source {
 	constructor(source, cachedData) {
 		super();
@@ -25,6 +51,16 @@ class CachedSource extends Source {
 		if (this._cachedSource) {
 			this.buffer();
 		}
+		const bufferedMaps = new Map();
+		for (const pair of this._cachedMaps) {
+			if (pair[1].bufferedMap === undefined) {
+				pair[1].bufferedMap = mapToBufferedMap(pair[1].map);
+			}
+			bufferedMaps.set(pair[0], {
+				map: undefined,
+				bufferedMap: pair[1].bufferedMap
+			});
+		}
 		return {
 			buffer: this._cachedBuffer,
 			source:
@@ -36,7 +72,7 @@ class CachedSource extends Source {
 					? false
 					: undefined,
 			size: this._cachedSize,
-			maps: this._cachedMaps
+			maps: bufferedMaps
 		};
 	}
 
@@ -88,35 +124,48 @@ class CachedSource extends Source {
 
 	sourceAndMap(options) {
 		const key = options ? JSON.stringify(options) : "{}";
-		let map = this._cachedMaps.get(key);
+		let cacheEntry = this._cachedMaps.get(key);
+		if (cacheEntry && cacheEntry.map === undefined) {
+			cacheEntry.map = bufferedMapToMap(cacheEntry.bufferedMap);
+		}
 		if (typeof this._cachedSource !== "undefined") {
-			if (map === undefined) {
-				map = this._source.map(options);
-				this._cachedMaps.set(key, map);
+			if (cacheEntry === undefined) {
+				const map = this._source.map(options);
+				this._cachedMaps.set(key, { map, bufferedMap: undefined });
+				return {
+					source: this._cachedSource,
+					map
+				};
+			} else {
+				return {
+					source: this._cachedSource,
+					map: cacheEntry.map
+				};
 			}
-			return {
-				source: this._cachedSource,
-				map
-			};
-		} else if (map !== undefined) {
+		} else if (cacheEntry !== undefined) {
 			return {
 				source: (this._cachedSource = this._source.source()),
-				map: this._cachedMaps[key]
+				map: cacheEntry.map
 			};
+		} else {
+			const result = this._source.sourceAndMap(options);
+			this._cachedSource = result.source;
+			this._cachedMaps.set(key, { map: result.map, bufferedMap: undefined });
+			return result;
 		}
-		const result = this._source.sourceAndMap(options);
-		this._cachedSource = result.source;
-		this._cachedMaps.set(key, result.map);
-		return result;
 	}
 
 	map(options) {
 		const key = options ? JSON.stringify(options) : "{}";
-		let map = this._cachedMaps.get(key);
-		if (map === undefined) {
-			map = this._source.map(options);
-			this._cachedMaps.set(key, map);
+		let cacheEntry = this._cachedMaps.get(key);
+		if (cacheEntry !== undefined) {
+			if (cacheEntry.map === undefined) {
+				cacheEntry.map = bufferedMapToMap(cacheEntry.bufferedMap);
+			}
+			return cacheEntry.map;
 		}
+		const map = this._source.map(options);
+		this._cachedMaps.set(key, { map, bufferedMap: undefined });
 		return map;
 	}
 

--- a/test/CachedSource.js
+++ b/test/CachedSource.js
@@ -271,4 +271,23 @@ describe("CachedSource", function() {
 			sourceAndMap: 0
 		});
 	});
+
+	it("should allow to store and restore cached data", () => {
+		const source = new CachedSource(
+			new OriginalSource("Hello World", "test.txt")
+		);
+
+		// fill up cache
+		source.source();
+		source.map({});
+		source.size();
+
+		const clone = new CachedSource(null, source.getCachedData());
+
+		clone.source().should.be.eql(source.source());
+		clone.buffer().should.be.eql(source.buffer());
+		clone.size().should.be.eql(source.size());
+		clone.map({}).should.be.eql(source.map({}));
+		clone.sourceAndMap({}).should.be.eql(source.sourceAndMap({}));
+	});
 });


### PR DESCRIPTION
avoid strings in CachedSource `map()` cache
and fix bug