### PR TITLE
Fix 'Error: "." is not in the SourceMap.'

### DIFF
--- a/lib/applySourceMap.js
+++ b/lib/applySourceMap.js
@@ -141,7 +141,7 @@ const applySourceMap = function (
 				// Set the source contents once
 				if (!("$" + source in rightSourceContentsSet)) {
 					rightSourceContentsSet["$" + source] = true;
-					const sourceContent = sourceMapConsumer.sourceContentFor(source);
+					const sourceContent = sourceMapConsumer.sourceContentFor(source, true);
 					if (sourceContent) {
 						l2rResult.setSourceContent(source, sourceContent);
 					}


### PR DESCRIPTION
Fixes the error: UnhandledPromiseRejectionWarning: Error: "." is not in the SourceMap.

Without the true parameter the function throws but we don't catch. With the true parameter the function returns null, which we check.