### PR TITLE
add workaround for bug in source-map

### DIFF
--- a/lib/applySourceMap.js
+++ b/lib/applySourceMap.js
@@ -127,26 +127,33 @@ const applySourceMap = function (
 				}
 
 				// Construct a left to right node from the found middle to right mapping
-				const source = m2rBestFit.source;
-				l2rOutput.push(
-					new SourceNode(
-						m2rBestFit.originalLine,
-						m2rBestFit.originalColumn,
-						source,
-						chunk,
-						allowMiddleName ? middleMapping.name : m2rBestFit.name
-					)
-				);
+				let source = m2rBestFit.source;
+				// Workaround for bug in source-map
+				// null sources are incorrectly normalized to "."
+				if (source && source !== ".") {
+					l2rOutput.push(
+						new SourceNode(
+							m2rBestFit.originalLine,
+							m2rBestFit.originalColumn,
+							source,
+							chunk,
+							allowMiddleName ? middleMapping.name : m2rBestFit.name
+						)
+					);
 
-				// Set the source contents once
-				if (!("$" + source in rightSourceContentsSet)) {
-					rightSourceContentsSet["$" + source] = true;
-					const sourceContent = sourceMapConsumer.sourceContentFor(source);
-					if (sourceContent) {
-						l2rResult.setSourceContent(source, sourceContent);
+					// Set the source contents once
+					if (!("$" + source in rightSourceContentsSet)) {
+						rightSourceContentsSet["$" + source] = true;
+						const sourceContent = sourceMapConsumer.sourceContentFor(
+							source,
+							true
+						);
+						if (sourceContent) {
+							l2rResult.setSourceContent(source, sourceContent);
+						}
 					}
+					return;
 				}
-				return;
 			}
 		}
 

--- a/test/SourceMapSource.js
+++ b/test/SourceMapSource.js
@@ -9,7 +9,8 @@ describe("SourceMapSource", () => {
 			["Hello World", "is a test string"].join("\n") + "\n";
 		const innerSource = new ConcatSource(
 			new OriginalSource(innerSourceCode, "hello-world.txt"),
-			"Other text\n"
+			new OriginalSource("Translate: ", "header.txt"),
+			"Other text"
 		);
 
 		const source = new SourceNode(null, null, null, [
@@ -20,9 +21,9 @@ describe("SourceMapSource", () => {
 			new SourceNode(2, 0, "text", "ist ein", "nope"),
 			" test ",
 			new SourceNode(2, 10, "text", "Text\n"),
-			new SourceNode(3, 0, "text", "Anderer"),
+			new SourceNode(3, 11, "text", "Anderer"),
 			" ",
-			new SourceNode(3, 6, "text", "Text")
+			new SourceNode(3, 17, "text", "Text")
 		]);
 		source.setSourceContent("text", innerSourceCode);
 
@@ -56,7 +57,7 @@ describe("SourceMapSource", () => {
 
 		expect(sourceMapSource1.map()).toEqual({
 			file: "x",
-			mappings: "YAAAA,K,CAAMC;AACN,O,MAAU;ACCV,O,CAAM",
+			mappings: "YAAAA,K,CAAMC;AACN,O,MAAU;ACCC,O,CAAM",
 			names: ["Hello", "World"],
 			sources: ["hello-world.txt", "text"],
 			sourcesContent: [innerSourceCode, innerSource.source()],
@@ -76,7 +77,7 @@ describe("SourceMapSource", () => {
 		sourceMapSource1.updateHash(hash);
 		const digest = hash.digest("hex");
 		expect(digest).toBe(
-			"c46f63c0329381f89b8882d60964808e95380dbac726c343a765200355875147"
+			"2de42bc8972534c146d0fadce8288cd9803c53fbd72bdfbbff7f062f6748e01e"
 		);
 
 		const clone = new SourceMapSource(...sourceMapSource1.getArgsAsBuffers());


### PR DESCRIPTION
fixes #89
fixes #90 

`source = null` incorrectly normalizes to `source = "."`