### PR TITLE
Instead of return an empty SourceMap in some cases, return null

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The `options` object can contain the following keys:
 ```typescript
 Source.prototype.sourceAndMap(options?: Object) -> {
 	source: String | Buffer,
-	map: Object
+	map: Object | null
 }
 ```
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -7,35 +7,46 @@
 const { SourceNode, SourceMapConsumer } = require("source-map");
 const { SourceListMap, fromStringWithSourceMap } = require("source-list-map");
 
-exports.getSourceAndMap = (source, options) => {
+exports.getSourceAndMap = (inputSource, options) => {
+	let source;
+	let map;
 	if (options && options.columns === false) {
-		return source.listMap(options).toStringWithSourceMap({
+		const res = inputSource.listMap(options).toStringWithSourceMap({
 			file: "x"
 		});
+		source = res.source;
+		map = res.map;
+	} else {
+		const res = inputSource.node(options).toStringWithSourceMap({
+			file: "x"
+		});
+		source = res.code;
+		map = res.map.toJSON();
 	}
+	if (!map || !map.sources || map.sources.length === 0) map = null;
 
-	const res = source.node(options).toStringWithSourceMap({
-		file: "x"
-	});
 	return {
-		source: res.code,
-		map: res.map.toJSON()
+		source,
+		map
 	};
 };
 
 exports.getMap = (source, options) => {
+	let map;
 	if (options && options.columns === false) {
-		return source.listMap(options).toStringWithSourceMap({
+		map = source.listMap(options).toStringWithSourceMap({
 			file: "x"
 		}).map;
+	} else {
+		map = source
+			.node(options)
+			.toStringWithSourceMap({
+				file: "x"
+			})
+			.map.toJSON();
 	}
-
-	return source
-		.node(options)
-		.toStringWithSourceMap({
-			file: "x"
-		})
-		.map.toJSON();
+	if (!map || !map.sources || map.sources.length === 0) return null;
+	return map;
 };
 
 exports.getNode = (source, options) => {

--- a/test/ConcatSource.js
+++ b/test/ConcatSource.js
@@ -135,4 +135,26 @@ describe("ConcatSource", () => {
 		clone.updateHash(hash3);
 		expect(hash3.digest("hex")).toEqual(digest);
 	});
+
+	it("should return null as map when only generated code is concatenated", () => {
+		const source = new ConcatSource(
+			"Hello World\n",
+			new RawSource("Hello World\n"),
+			""
+		);
+
+		const resultText = source.source();
+		const resultMap = source.sourceAndMap({
+			columns: true
+		});
+		const resultListMap = source.sourceAndMap({
+			columns: false
+		});
+
+		expect(resultText).toBe("Hello World\nHello World\n");
+		expect(resultMap.source).toEqual(resultText);
+		expect(resultListMap.source).toEqual(resultText);
+		expect(resultListMap.map).toBe(null);
+		expect(resultMap.map).toBe(null);
+	});
 });

--- a/test/OriginalSource.js
+++ b/test/OriginalSource.js
@@ -39,12 +39,8 @@ describe("OriginalSource", () => {
 		expect(resultText).toBe("");
 		expect(resultMap.source).toEqual(resultText);
 		expect(resultListMap.source).toEqual(resultText);
-		expect(resultListMap.map.file).toEqual(resultMap.map.file);
-		expect(resultListMap.map.version).toEqual(resultMap.map.version);
-		expect(resultMap.map.sources).toEqual([]);
-		expect(resultListMap.map.sources).toEqual(resultMap.map.sources);
-		expect(resultMap.map.mappings).toBe("");
-		expect(resultListMap.map.mappings).toBe("");
+		expect(resultListMap.map).toBe(null);
+		expect(resultMap.map).toBe(null);
 	});
 
 	it("should omit mappings for columns with node", () => {


### PR DESCRIPTION
`map()` and `sourceAndMap()` should return null when no SourceMap is available