### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,13 @@ matrix:
       node_js: "12"
     - os: osx
       node_js: "10"
+# ppc64le support code
+    - arch: ppc64le
+      node_js: "14"
+    - arch: ppc64le
+      node_js: "12"
+    - arch: ppc64le
+      node_js: "10"
   fast_finish: true
 
 script: yarn travis


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.
The build and test results are available at the below location.
https://travis-ci.com/github/nageshlop/webpack-sources