### PR TITLE
Let `CachedSource` cache `node` and `listMap` methods

### DIFF
--- a/lib/CachedSource.js
+++ b/lib/CachedSource.js
@@ -70,13 +70,6 @@ class CachedSource extends Source {
 	}
 
 	getCachedData() {
-		// We don't want to cache strings
-		// So if we have a caches sources
-		// create a buffer from it and only store
-		// if it was a Buffer or string
-		if (this._cachedSource) {
-			this.buffer();
-		}
 		const bufferedMaps = new Map();
 		for (const pair of this._cachedMaps) {
 			let cacheEntry = pair[1];
@@ -91,6 +84,13 @@ class CachedSource extends Source {
 				listMap: undefined,
 				bufferedMap: cacheEntry.bufferedMap
 			});
+		}
+		// We don't want to cache strings
+		// So if we have a caches sources
+		// create a buffer from it and only store
+		// if it was a Buffer or string
+		if (this._cachedSource) {
+			this.buffer();
 		}
 		return {
 			buffer: this._cachedBuffer,

--- a/lib/CachedSource.js
+++ b/lib/CachedSource.js
@@ -5,6 +5,8 @@
 "use strict";
 
 const Source = require("./Source");
+const { SourceMapConsumer, SourceNode } = require("source-map");
+const { SourceListMap, fromStringWithSourceMap } = require("source-list-map");
 
 const mapToBufferedMap = map => {
 	if (typeof map !== "object" || !map) return map;
@@ -56,12 +58,18 @@ class CachedSource extends Source {
 		}
 		const bufferedMaps = new Map();
 		for (const pair of this._cachedMaps) {
-			if (pair[1].bufferedMap === undefined) {
-				pair[1].bufferedMap = mapToBufferedMap(pair[1].map);
+			let cacheEntry = pair[1];
+			if (cacheEntry.bufferedMap === undefined) {
+				if (cacheEntry.map === undefined) {
+					continue;
+				}
+				cacheEntry.bufferedMap = mapToBufferedMap(cacheEntry.map);
 			}
 			bufferedMaps.set(pair[0], {
 				map: undefined,
-				bufferedMap: pair[1].bufferedMap
+				node: undefined,
+				listMap: undefined,
+				bufferedMap: cacheEntry.bufferedMap
 			});
 		}
 		return {
@@ -131,48 +139,162 @@ class CachedSource extends Source {
 
 	sourceAndMap(options) {
 		const key = options ? JSON.stringify(options) : "{}";
-		let cacheEntry = this._cachedMaps.get(key);
-		if (cacheEntry && cacheEntry.map === undefined) {
+		const cacheEntry = this._cachedMaps.get(key);
+		if (
+			cacheEntry !== undefined &&
+			cacheEntry.map === undefined &&
+			cacheEntry.bufferedMap !== undefined
+		) {
 			cacheEntry.map = bufferedMapToMap(cacheEntry.bufferedMap);
 		}
-		if (typeof this._cachedSource !== "undefined") {
-			if (cacheEntry === undefined) {
-				const map = this.original().map(options);
-				this._cachedMaps.set(key, { map, bufferedMap: undefined });
-				return {
-					source: this._cachedSource,
-					map
-				};
+
+		let source, map;
+		if (cacheEntry === undefined || cacheEntry.map === undefined) {
+			if (typeof this._cachedSource !== "undefined") {
+				// The source is already known so only compute the map.
+				source = this._cachedSource;
+				map = this.original().map(options);
 			} else {
-				return {
-					source: this._cachedSource,
-					map: cacheEntry.map
-				};
+				// The source is not yet known so compute the source and map together.
+				const sourceAndMap = this.original().sourceAndMap(options);
+				source = sourceAndMap.source;
+				map = sourceAndMap.map;
+				this._cachedSource = source;
 			}
-		} else if (cacheEntry !== undefined) {
-			return {
-				source: (this._cachedSource = this.original().source()),
-				map: cacheEntry.map
-			};
+
+			if (cacheEntry === undefined) {
+				this._cachedMaps.set(key, {
+					map,
+					node: undefined,
+					listMap: undefined,
+					bufferedMap: undefined
+				});
+			} else {
+				cacheEntry.map = map;
+			}
 		} else {
-			const result = this.original().sourceAndMap(options);
-			this._cachedSource = result.source;
-			this._cachedMaps.set(key, { map: result.map, bufferedMap: undefined });
-			return result;
+			// The map is already cached.
+			source = this.source();
+			map = cacheEntry.map;
+		}
+		return { source, map };
+	}
+
+	node(options) {
+		const key = options ? JSON.stringify(options) : "{}";
+		let cacheEntry = this._cachedMaps.get(key);
+		if (cacheEntry === undefined || cacheEntry.node === undefined) {
+			const original = this.original();
+			let node;
+
+			if (
+				typeof original.node === "function" &&
+				(cacheEntry === undefined ||
+					(cacheEntry.map === undefined &&
+						cacheEntry.bufferedMap === undefined))
+			) {
+				// The original source is able to provide a node and a cached map is not
+				// available, so the node is obtained by requesting it from the original
+				// source.
+				node = original.node(options);
+			} else {
+				const sourceAndMap = this.sourceAndMap(options);
+				if (sourceAndMap.map) {
+					node = SourceNode.fromStringWithSourceMap(
+						sourceAndMap.source,
+						new SourceMapConsumer(sourceAndMap.map)
+					);
+				} else {
+					node = new SourceNode(null, null, null, sourceAndMap.source);
+				}
+				// Refresh the cache entry as it may have been primed in `sourceAndMap`.
+				cacheEntry = this._cachedMaps.get(key);
+			}
+
+			if (cacheEntry === undefined) {
+				this._cachedMaps.set(key, {
+					map: undefined,
+					node,
+					listMap: undefined,
+					bufferedMap: undefined
+				});
+			} else {
+				cacheEntry.node = node;
+			}
+			return node;
+		} else {
+			return cacheEntry.node;
+		}
+	}
+
+	listMap(options) {
+		const key = options ? JSON.stringify(options) : "{}";
+		let cacheEntry = this._cachedMaps.get(key);
+		if (cacheEntry === undefined || cacheEntry.listMap === undefined) {
+			const original = this.original();
+			let listMap;
+
+			if (
+				typeof original.listMap === "function" &&
+				(cacheEntry === undefined ||
+					(cacheEntry.map === undefined &&
+						cacheEntry.bufferedMap === undefined))
+			) {
+				// The original source is able to provide a list map and a cached map is
+				// not available, so the list map is obtained by requesting it from the
+				// original source.
+				listMap = original.listMap(options);
+			} else {
+				const sourceAndMap = this.sourceAndMap(options);
+				if (sourceAndMap.map) {
+					listMap = fromStringWithSourceMap(
+						sourceAndMap.source,
+						sourceAndMap.map
+					);
+				} else {
+					listMap = new SourceListMap(sourceAndMap.source);
+				}
+				// Refresh the cache entry as it may have been primed in `sourceAndMap`.
+				cacheEntry = this._cachedMaps.get(key);
+			}
+
+			if (cacheEntry === undefined) {
+				this._cachedMaps.set(key, {
+					map: undefined,
+					node: undefined,
+					listMap,
+					bufferedMap: undefined
+				});
+			} else {
+				cacheEntry.listMap = listMap;
+			}
+
+			return listMap;
+		} else {
+			return cacheEntry.listMap;
 		}
 	}
 
 	map(options) {
 		const key = options ? JSON.stringify(options) : "{}";
-		let cacheEntry = this._cachedMaps.get(key);
-		if (cacheEntry !== undefined) {
-			if (cacheEntry.map === undefined) {
-				cacheEntry.map = bufferedMapToMap(cacheEntry.bufferedMap);
-			}
+		const cacheEntry = this._cachedMaps.get(key);
+		if (
+			cacheEntry !== undefined &&
+			cacheEntry.map === undefined &&
+			cacheEntry.bufferedMap !== undefined
+		) {
+			cacheEntry.map = bufferedMapToMap(cacheEntry.bufferedMap);
+		}
+		if (cacheEntry !== undefined && cacheEntry.map !== undefined) {
 			return cacheEntry.map;
 		}
 		const map = this.original().map(options);
-		this._cachedMaps.set(key, { map, bufferedMap: undefined });
+		this._cachedMaps.set(key, {
+			map,
+			node: undefined,
+			listMap: undefined,
+			bufferedMap: undefined
+		});
 		return map;
 	}
 

--- a/lib/CachedSource.js
+++ b/lib/CachedSource.js
@@ -8,6 +8,8 @@ const Source = require("./Source");
 const { SourceMapConsumer, SourceNode } = require("source-map");
 const { SourceListMap, fromStringWithSourceMap } = require("source-list-map");
 
+const LIST_MAP_OPTIONS = { columns: false };
+
 const mapToBufferedMap = map => {
 	if (typeof map !== "object" || !map) return map;
 	const bufferedMap = Object.assign({}, map);
@@ -36,6 +38,25 @@ const bufferedMapToMap = bufferedMap => {
 	return map;
 };
 
+const sourceAndMapToNode = (source, map) => {
+	if (map) {
+		return SourceNode.fromStringWithSourceMap(
+			source,
+			new SourceMapConsumer(map)
+		);
+	} else {
+		return new SourceNode(null, null, null, source);
+	}
+};
+
+const sourceAndMapToListMap = (source, map) => {
+	if (map) {
+		return fromStringWithSourceMap(source, map);
+	} else {
+		return new SourceListMap(source);
+	}
+};
+
 class CachedSource extends Source {
 	constructor(source, cachedData) {
 		super();
@@ -60,10 +81,9 @@ class CachedSource extends Source {
 		for (const pair of this._cachedMaps) {
 			let cacheEntry = pair[1];
 			if (cacheEntry.bufferedMap === undefined) {
-				if (cacheEntry.map === undefined) {
-					continue;
-				}
-				cacheEntry.bufferedMap = mapToBufferedMap(cacheEntry.map);
+				cacheEntry.bufferedMap = mapToBufferedMap(
+					this._getMapFromCacheEntry(cacheEntry)
+				);
 			}
 			bufferedMaps.set(pair[0], {
 				map: undefined,
@@ -98,19 +118,51 @@ class CachedSource extends Source {
 	}
 
 	source() {
+		const source = this._getCachedSource();
+		if (source !== undefined) return source;
+		return (this._cachedSource = this.original().source());
+	}
+
+	_getMapFromCacheEntry(cacheEntry) {
+		if (cacheEntry.map !== undefined) {
+			return cacheEntry.map;
+		} else if (cacheEntry.bufferedMap !== undefined) {
+			return (cacheEntry.map = bufferedMapToMap(cacheEntry.bufferedMap));
+		} else if (cacheEntry.node !== undefined) {
+			const result = cacheEntry.node.toStringWithSourceMap({
+				file: "x"
+			});
+			if (this._cachedSource === undefined) this._cachedSource = result.code;
+			return (cacheEntry.map = result.map.toJSON());
+		} else if (cacheEntry.listMap !== undefined) {
+			const result = cacheEntry.listMap.toStringWithSourceMap({
+				file: "x"
+			});
+			if (this._cachedSource === undefined) this._cachedSource = result.source;
+			return (cacheEntry.map = result.map);
+		}
+	}
+
+	_getCachedSource() {
 		if (this._cachedSource !== undefined) return this._cachedSource;
 		if (this._cachedBuffer && this._cachedSourceType !== undefined) {
 			return (this._cachedSource = this._cachedSourceType
 				? this._cachedBuffer.toString("utf-8")
 				: this._cachedBuffer);
-		} else {
-			return (this._cachedSource = this.original().source());
+		}
+		for (const cacheEntry of this._cachedMaps.values()) {
+			if (cacheEntry.node !== undefined) {
+				return (this._cachedSource = cacheEntry.node.toString());
+			}
+			if (cacheEntry.listMap !== undefined) {
+				return (this._cachedSource = cacheEntry.listMap.toString());
+			}
 		}
 	}
 
 	buffer() {
-		if (typeof this._cachedBuffer !== "undefined") return this._cachedBuffer;
-		if (typeof this._cachedSource !== "undefined") {
+		if (this._cachedBuffer !== undefined) return this._cachedBuffer;
+		if (this._cachedSource !== undefined) {
 			if (Buffer.isBuffer(this._cachedSource)) {
 				return (this._cachedBuffer = this._cachedSource);
 			}
@@ -127,12 +179,13 @@ class CachedSource extends Source {
 	}
 
 	size() {
-		if (typeof this._cachedSize !== "undefined") return this._cachedSize;
-		if (typeof this._cachedSource !== "undefined") {
-			return (this._cachedSize = Buffer.byteLength(this._cachedSource));
-		}
-		if (typeof this._cachedBuffer !== "undefined") {
+		if (this._cachedSize !== undefined) return this._cachedSize;
+		if (this._cachedBuffer !== undefined) {
 			return (this._cachedSize = this._cachedBuffer.length);
+		}
+		const source = this._getCachedSource();
+		if (source !== undefined) {
+			return (this._cachedSize = Buffer.byteLength(source));
 		}
 		return (this._cachedSize = this.original().size());
 	}
@@ -140,153 +193,114 @@ class CachedSource extends Source {
 	sourceAndMap(options) {
 		const key = options ? JSON.stringify(options) : "{}";
 		const cacheEntry = this._cachedMaps.get(key);
-		if (
-			cacheEntry !== undefined &&
-			cacheEntry.map === undefined &&
-			cacheEntry.bufferedMap !== undefined
-		) {
-			cacheEntry.map = bufferedMapToMap(cacheEntry.bufferedMap);
+		// Look for a cached map
+		if (cacheEntry !== undefined) {
+			// We have a cached map in some representation
+			const map = this._getMapFromCacheEntry(cacheEntry);
+			// Either get the cached source or compute it
+			return { source: this.source(), map };
 		}
-
-		let source, map;
-		if (cacheEntry === undefined || cacheEntry.map === undefined) {
-			if (typeof this._cachedSource !== "undefined") {
-				// The source is already known so only compute the map.
-				source = this._cachedSource;
-				map = this.original().map(options);
-			} else {
-				// The source is not yet known so compute the source and map together.
-				const sourceAndMap = this.original().sourceAndMap(options);
-				source = sourceAndMap.source;
-				map = sourceAndMap.map;
-				this._cachedSource = source;
-			}
-
-			if (cacheEntry === undefined) {
-				this._cachedMaps.set(key, {
-					map,
-					node: undefined,
-					listMap: undefined,
-					bufferedMap: undefined
-				});
-			} else {
-				cacheEntry.map = map;
-			}
+		// Look for a cached source
+		let source = this._getCachedSource();
+		// Compute the map
+		let map;
+		if (source !== undefined) {
+			map = this.original().map(options);
 		} else {
-			// The map is already cached.
-			source = this.source();
-			map = cacheEntry.map;
+			// Compute the source and map together.
+			const sourceAndMap = this.original().sourceAndMap(options);
+			source = sourceAndMap.source;
+			map = sourceAndMap.map;
+			this._cachedSource = source;
 		}
+		this._cachedMaps.set(key, {
+			map,
+			node: undefined,
+			listMap: undefined,
+			bufferedMap: undefined
+		});
 		return { source, map };
 	}
 
 	node(options) {
 		const key = options ? JSON.stringify(options) : "{}";
 		let cacheEntry = this._cachedMaps.get(key);
-		if (cacheEntry === undefined || cacheEntry.node === undefined) {
-			const original = this.original();
-			let node;
-
-			if (
-				typeof original.node === "function" &&
-				(cacheEntry === undefined ||
-					(cacheEntry.map === undefined &&
-						cacheEntry.bufferedMap === undefined))
-			) {
-				// The original source is able to provide a node and a cached map is not
-				// available, so the node is obtained by requesting it from the original
-				// source.
-				node = original.node(options);
-			} else {
-				const sourceAndMap = this.sourceAndMap(options);
-				if (sourceAndMap.map) {
-					node = SourceNode.fromStringWithSourceMap(
-						sourceAndMap.source,
-						new SourceMapConsumer(sourceAndMap.map)
-					);
-				} else {
-					node = new SourceNode(null, null, null, sourceAndMap.source);
-				}
-				// Refresh the cache entry as it may have been primed in `sourceAndMap`.
-				cacheEntry = this._cachedMaps.get(key);
-			}
-
-			if (cacheEntry === undefined) {
-				this._cachedMaps.set(key, {
-					map: undefined,
-					node,
-					listMap: undefined,
-					bufferedMap: undefined
-				});
-			} else {
-				cacheEntry.node = node;
-			}
+		// Check cache
+		if (cacheEntry !== undefined) {
+			// Directly cached
+			if (cacheEntry.node) return cacheEntry.node;
+			// Construct from cached map
+			const map = this._getMapFromCacheEntry(cacheEntry);
+			const source = this.source();
+			const node = sourceAndMapToNode(source, map);
+			cacheEntry.node = node;
 			return node;
-		} else {
-			return cacheEntry.node;
 		}
+		let node;
+		const original = this.original();
+		if (typeof original.node === "function") {
+			node = original.node(options);
+			this._cachedMaps.set(key, {
+				map: undefined,
+				node,
+				listMap: undefined,
+				bufferedMap: undefined
+			});
+		} else {
+			const sourceAndMap = this.sourceAndMap(options);
+			node = sourceAndMapToNode(sourceAndMap.source, sourceAndMap.map);
+			this._cachedMaps.get(key).node = node;
+		}
+		return node;
 	}
 
 	listMap(options) {
-		const key = options ? JSON.stringify(options) : "{}";
-		let cacheEntry = this._cachedMaps.get(key);
-		if (cacheEntry === undefined || cacheEntry.listMap === undefined) {
-			const original = this.original();
-			let listMap;
-
-			if (
-				typeof original.listMap === "function" &&
-				(cacheEntry === undefined ||
-					(cacheEntry.map === undefined &&
-						cacheEntry.bufferedMap === undefined))
-			) {
-				// The original source is able to provide a list map and a cached map is
-				// not available, so the list map is obtained by requesting it from the
-				// original source.
-				listMap = original.listMap(options);
-			} else {
-				const sourceAndMap = this.sourceAndMap(options);
-				if (sourceAndMap.map) {
-					listMap = fromStringWithSourceMap(
-						sourceAndMap.source,
-						sourceAndMap.map
-					);
-				} else {
-					listMap = new SourceListMap(sourceAndMap.source);
-				}
-				// Refresh the cache entry as it may have been primed in `sourceAndMap`.
-				cacheEntry = this._cachedMaps.get(key);
-			}
-
-			if (cacheEntry === undefined) {
-				this._cachedMaps.set(key, {
-					map: undefined,
-					node: undefined,
-					listMap,
-					bufferedMap: undefined
-				});
-			} else {
-				cacheEntry.listMap = listMap;
-			}
-
-			return listMap;
+		let key;
+		// Enforce options must include columns: false
+		if (!options) {
+			key = '{"columns":false}';
+			options = LIST_MAP_OPTIONS;
 		} else {
-			return cacheEntry.listMap;
+			if (options.columns !== false) {
+				options = Object.assign({}, options, LIST_MAP_OPTIONS);
+			}
+			key = JSON.stringify(options);
 		}
+		// Check cache
+		let cacheEntry = this._cachedMaps.get(key);
+		if (cacheEntry !== undefined) {
+			// Directly cached
+			if (cacheEntry.listMap) return cacheEntry.listMap;
+			// Construct from cached map
+			const map = this._getMapFromCacheEntry(cacheEntry);
+			const source = this.source();
+			const listMap = sourceAndMapToListMap(source, map);
+			cacheEntry.listMap = listMap;
+			return listMap;
+		}
+		let listMap;
+		const original = this.original();
+		if (typeof original.listMap === "function") {
+			listMap = original.listMap(options);
+			this._cachedMaps.set(key, {
+				map: undefined,
+				node: undefined,
+				listMap,
+				bufferedMap: undefined
+			});
+		} else {
+			const sourceAndMap = this.sourceAndMap(options);
+			listMap = sourceAndMapToListMap(sourceAndMap.source, sourceAndMap.map);
+			this._cachedMaps.get(key).listMap = listMap;
+		}
+		return listMap;
 	}
 
 	map(options) {
 		const key = options ? JSON.stringify(options) : "{}";
 		const cacheEntry = this._cachedMaps.get(key);
-		if (
-			cacheEntry !== undefined &&
-			cacheEntry.map === undefined &&
-			cacheEntry.bufferedMap !== undefined
-		) {
-			cacheEntry.map = bufferedMapToMap(cacheEntry.bufferedMap);
-		}
-		if (cacheEntry !== undefined && cacheEntry.map !== undefined) {
-			return cacheEntry.map;
+		if (cacheEntry !== undefined) {
+			return this._getMapFromCacheEntry(cacheEntry);
 		}
 		const map = this.original().map(options);
 		this._cachedMaps.set(key, {

--- a/test/CachedSource.js
+++ b/test/CachedSource.js
@@ -3,6 +3,7 @@ const CachedSource = require("../").CachedSource;
 const OriginalSource = require("../").OriginalSource;
 const RawSource = require("../").RawSource;
 const Source = require("../").Source;
+const { getNode, getListMap } = require("../lib/helpers");
 
 class TrackedSource extends Source {
 	constructor(source) {
@@ -205,6 +206,161 @@ describe("CachedSource", () => {
 			hash: 0
 		});
 	});
+
+	it("should use `node` for sources that provide it", () => {
+		const original = new OriginalSource("TestTestTest", "file.js");
+		const source = new TrackedSource(original);
+		const cachedSource = new CachedSource(source);
+
+		let nodeCalled = 0;
+		source.node = options => {
+			nodeCalled++;
+			return getNode(original, options);
+		};
+
+		const node = cachedSource.node();
+		const sourceMap = node.toStringWithSourceMap({
+			file: "x"
+		});
+		expect(sourceMap.code).toBe("TestTestTest");
+		expect(sourceMap.map.toJSON()).toEqual(original.map({}));
+		expect(cachedSource.node()).toBe(node);
+		expect(nodeCalled).toBe(1);
+		expect(source.getCalls()).toEqual({
+			size: 0,
+			source: 0,
+			buffer: 0,
+			map: 0,
+			sourceAndMap: 0,
+			hash: 0
+		});
+
+		const sourceAndMap = cachedSource.sourceAndMap();
+		const map = cachedSource.map();
+		expect(sourceAndMap.map).toEqual(sourceMap.map.toJSON());
+		expect(map).toEqual(sourceMap.map.toJSON());
+		expect(source.getCalls()).toEqual({
+			size: 0,
+			source: 0,
+			buffer: 0,
+			map: 0,
+			sourceAndMap: 1,
+			hash: 0
+		});
+	});
+
+	it("should use sourceAndMap cache for `node` when source does not provide `node`", () => {
+		const original = new OriginalSource("TestTestTest", "file.js");
+		const source = new TrackedSource(original);
+		const cachedSource = new CachedSource(source);
+
+		const node = cachedSource.node();
+		const sourceMap = node.toStringWithSourceMap({
+			file: "x"
+		});
+		expect(sourceMap.code).toBe("TestTestTest");
+		expect(sourceMap.map.toJSON()).toEqual(original.map({}));
+		expect(cachedSource.node()).toBe(node);
+		expect(source.getCalls()).toEqual({
+			size: 0,
+			source: 0,
+			buffer: 0,
+			map: 0,
+			sourceAndMap: 1,
+			hash: 0
+		});
+
+		const sourceAndMap = cachedSource.sourceAndMap();
+		const map = cachedSource.map();
+		expect(sourceAndMap.map).toEqual(sourceMap.map.toJSON());
+		expect(map).toEqual(sourceMap.map.toJSON());
+		expect(source.getCalls()).toEqual({
+			size: 0,
+			source: 0,
+			buffer: 0,
+			map: 0,
+			sourceAndMap: 1,
+			hash: 0
+		});
+	});
+
+	it("should use `listMap` for sources that provide it", () => {
+		const original = new OriginalSource("TestTestTest", "file.js");
+		const source = new TrackedSource(original);
+		const cachedSource = new CachedSource(source);
+
+		let listMapCalled = 0;
+		source.listMap = options => {
+			listMapCalled++;
+			return getListMap(original, options);
+		};
+
+		const listMap = cachedSource.listMap();
+		const sourceMap = listMap.toStringWithSourceMap({
+			file: "x"
+		});
+		expect(sourceMap.source).toBe("TestTestTest");
+		expect(sourceMap.map).toEqual(original.map({ columns: false }));
+		expect(cachedSource.listMap()).toBe(listMap);
+		expect(listMapCalled).toBe(1);
+		expect(source.getCalls()).toEqual({
+			size: 0,
+			source: 0,
+			buffer: 0,
+			map: 0,
+			sourceAndMap: 0,
+			hash: 0
+		});
+
+		const sourceAndMap = cachedSource.sourceAndMap();
+		const map = cachedSource.map();
+		expect(sourceAndMap.map).toEqual(original.map());
+		expect(map).toEqual(original.map());
+		expect(source.getCalls()).toEqual({
+			size: 0,
+			source: 0,
+			buffer: 0,
+			map: 0,
+			sourceAndMap: 1,
+			hash: 0
+		});
+	});
+
+	it("should use sourceAndMap cache for `listMap` when source does not provide `listMap`", () => {
+		const original = new OriginalSource("TestTestTest", "file.js");
+		const source = new TrackedSource(original);
+		const cachedSource = new CachedSource(source);
+
+		const listMap = cachedSource.listMap();
+		const sourceMap = listMap.toStringWithSourceMap({
+			file: "x"
+		});
+		expect(sourceMap.source).toBe("TestTestTest");
+		expect(sourceMap.map).toEqual(original.map({ columns: false }));
+		expect(cachedSource.listMap()).toBe(listMap);
+		expect(source.getCalls()).toEqual({
+			size: 0,
+			source: 0,
+			buffer: 0,
+			map: 0,
+			sourceAndMap: 1,
+			hash: 0
+		});
+
+		const sourceAndMap = cachedSource.sourceAndMap();
+		const map = cachedSource.map();
+		expect(sourceAndMap.map).toEqual(original.map());
+		expect(map).toEqual(original.map());
+		expect(source.getCalls()).toEqual({
+			size: 0,
+			source: 0,
+			buffer: 0,
+			map: 0,
+			sourceAndMap: 1,
+			hash: 0
+		});
+	});
+
 	it("should use binary source for buffer", () => {
 		const buffer = Buffer.from(new Array(256));
 		const source = new TrackedSource(new RawSource(buffer));
@@ -266,6 +422,34 @@ describe("CachedSource", () => {
 			sourceAndMap: 0,
 			hash: 0
 		});
+	});
+
+	it("should not include map in the cache if only a node was computed", () => {
+		const original = new OriginalSource("Hello World", "test.txt");
+		const source = new TrackedSource(original);
+		const cachedSource = new CachedSource(source);
+
+		source.node = options => getNode(original, options);
+
+		// fill up cache
+		cachedSource.node();
+
+		const cachedData = cachedSource.getCachedData();
+		expect(cachedData.maps.size).toBe(0);
+	});
+
+	it("should not include map in the cache if only a listMap was computed", () => {
+		const original = new OriginalSource("Hello World", "test.txt");
+		const source = new TrackedSource(original);
+		const cachedSource = new CachedSource(source);
+
+		source.listMap = options => getListMap(original, options);
+
+		// fill up cache
+		cachedSource.listMap();
+
+		const cachedData = cachedSource.getCachedData();
+		expect(cachedData.maps.size).toBe(0);
 	});
 
 	it("should allow to store and restore cached data (with SourceMap)", () => {

--- a/test/CachedSource.js
+++ b/test/CachedSource.js
@@ -244,7 +244,7 @@ describe("CachedSource", () => {
 			source: 0,
 			buffer: 0,
 			map: 0,
-			sourceAndMap: 1,
+			sourceAndMap: 0,
 			hash: 0
 		});
 	});
@@ -320,8 +320,8 @@ describe("CachedSource", () => {
 			size: 0,
 			source: 0,
 			buffer: 0,
-			map: 0,
-			sourceAndMap: 1,
+			map: 1,
+			sourceAndMap: 0,
 			hash: 0
 		});
 	});
@@ -355,8 +355,8 @@ describe("CachedSource", () => {
 			size: 0,
 			source: 0,
 			buffer: 0,
-			map: 0,
-			sourceAndMap: 1,
+			map: 1, // second: with columns: undefined/true
+			sourceAndMap: 1, // first: with columns: false
 			hash: 0
 		});
 	});
@@ -424,7 +424,7 @@ describe("CachedSource", () => {
 		});
 	});
 
-	it("should not include map in the cache if only a node was computed", () => {
+	it("should include map in the cache if only a node was computed", () => {
 		const original = new OriginalSource("Hello World", "test.txt");
 		const source = new TrackedSource(original);
 		const cachedSource = new CachedSource(source);
@@ -435,10 +435,10 @@ describe("CachedSource", () => {
 		cachedSource.node();
 
 		const cachedData = cachedSource.getCachedData();
-		expect(cachedData.maps.size).toBe(0);
+		expect(cachedData.maps.size).toBe(1);
 	});
 
-	it("should not include map in the cache if only a listMap was computed", () => {
+	it("should include map in the cache if only a listMap was computed", () => {
 		const original = new OriginalSource("Hello World", "test.txt");
 		const source = new TrackedSource(original);
 		const cachedSource = new CachedSource(source);
@@ -449,7 +449,7 @@ describe("CachedSource", () => {
 		cachedSource.listMap();
 
 		const cachedData = cachedSource.getCachedData();
-		expect(cachedData.maps.size).toBe(0);
+		expect(cachedData.maps.size).toBe(1);
 	});
 
 	it("should allow to store and restore cached data (with SourceMap)", () => {
@@ -470,6 +470,15 @@ describe("CachedSource", () => {
 		expect(clone.map({})).toEqual(source.map({}));
 		expect(clone.sourceAndMap({})).toEqual(source.sourceAndMap({}));
 		expect(getHash(clone)).toBe(getHash(original));
+
+		const clone2 = new CachedSource(null, clone.getCachedData());
+
+		expect(clone2.source()).toEqual(source.source());
+		expect(clone2.buffer()).toEqual(source.buffer());
+		expect(clone2.size()).toEqual(source.size());
+		expect(clone2.map({})).toEqual(source.map({}));
+		expect(clone2.sourceAndMap({})).toEqual(source.sourceAndMap({}));
+		expect(getHash(clone2)).toBe(getHash(original));
 	});
 
 	it("should allow to store and restore cached data (without SourceMap)", () => {

--- a/test/CachedSource.js
+++ b/test/CachedSource.js
@@ -249,6 +249,48 @@ describe("CachedSource", () => {
 		});
 	});
 
+	it("should use sourceAndMap cache for `node` for sources that provide it", () => {
+		const original = new OriginalSource("TestTestTest", "file.js");
+		const source = new TrackedSource(original);
+		const cachedSource = new CachedSource(source);
+
+		let nodeCalled = 0;
+		source.node = options => {
+			nodeCalled++;
+			return getNode(original, options);
+		};
+
+		const sourceAndMap = cachedSource.sourceAndMap();
+		const map = cachedSource.map();
+		expect(sourceAndMap.map).toEqual(original.map({}));
+		expect(map).toEqual(original.map({}));
+		expect(source.getCalls()).toEqual({
+			size: 0,
+			source: 0,
+			buffer: 0,
+			map: 0,
+			sourceAndMap: 1,
+			hash: 0
+		});
+
+		const node = cachedSource.node();
+		const sourceMap = node.toStringWithSourceMap({
+			file: "x"
+		});
+		expect(sourceMap.code).toBe("TestTestTest");
+		expect(sourceMap.map.toJSON()).toEqual(sourceAndMap.map);
+		expect(cachedSource.node()).toBe(node);
+		expect(nodeCalled).toBe(0);
+		expect(source.getCalls()).toEqual({
+			size: 0,
+			source: 0,
+			buffer: 0,
+			map: 0,
+			sourceAndMap: 1,
+			hash: 0
+		});
+	});
+
 	it("should use sourceAndMap cache for `node` when source does not provide `node`", () => {
 		const original = new OriginalSource("TestTestTest", "file.js");
 		const source = new TrackedSource(original);
@@ -322,6 +364,49 @@ describe("CachedSource", () => {
 			buffer: 0,
 			map: 1,
 			sourceAndMap: 0,
+			hash: 0
+		});
+	});
+
+	it("should use sourceAndMap cache for `listMap` for sources that provide it", () => {
+		const original = new OriginalSource("TestTestTest", "file.js");
+		const source = new TrackedSource(original);
+		const cachedSource = new CachedSource(source);
+
+		let listMapCalled = 0;
+		source.listMap = options => {
+			listMapCalled++;
+			return getListMap(original, options);
+		};
+
+		const sourceAndMap = cachedSource.sourceAndMap({ columns: false });
+		const map = cachedSource.map({ columns: false });
+		expect(sourceAndMap.map).toEqual(original.map({ columns: false }));
+		expect(map).toEqual(original.map({ columns: false }));
+		expect(source.getCalls()).toEqual({
+			size: 0,
+			source: 0,
+			buffer: 0,
+			map: 0,
+			sourceAndMap: 1,
+			hash: 0
+		});
+
+		const listMap = cachedSource.listMap({});
+		const sourceMap = listMap.toStringWithSourceMap({
+			file: "x"
+		});
+		expect(sourceMap.source).toBe("TestTestTest");
+		expect(sourceMap.map).toEqual(original.map({ columns: false }));
+		expect(cachedSource.listMap()).toBe(listMap);
+		expect(cachedSource.listMap({ columns: false })).toBe(listMap);
+		expect(listMapCalled).toBe(0);
+		expect(source.getCalls()).toEqual({
+			size: 0,
+			source: 0,
+			buffer: 0,
+			map: 0,
+			sourceAndMap: 1,
 			hash: 0
 		});
 	});


### PR DESCRIPTION
Since development on webpack-sources 2.0 began in 993d98fdece701ca8373356fd56afe373f8ae84a
the `CachedSource` implementation would no longer delegate the original source's `node` and
`listMap` methods. Instead, a `SourceNode` is now instead be generated using the `sourceAndMap`
method from which a `SourceNode` is then created using a `SourceMapConsumer`. This adds a
significant performance penalty, as creating a `SourceNode` without going through an explicit
source map object and then parsing it again can be much cheaper.

This commit reintroduces `CachedSource.node` and `CachedSource.listMap` to re-enable the fast
path of creating a `SourceNode`.