### PR TITLE
Implement `SourceMapSource.buffer` for efficient size computation

### DIFF
--- a/lib/SourceMapSource.js
+++ b/lib/SourceMapSource.js
@@ -158,6 +158,11 @@ class SourceMapSource extends Source {
 		];
 	}
 
+	buffer() {
+		this._ensureValueBuffer();
+		return this._valueAsBuffer;
+	}
+
 	source() {
 		this._ensureValueString();
 		return this._valueAsString;

--- a/test/SourceMapSource.js
+++ b/test/SourceMapSource.js
@@ -426,4 +426,27 @@ describe("SourceMapSource", () => {
 		}
 	`);
 	});
+
+	it("provides buffer when backed by string", () => {
+		const sourceMapSource = new SourceMapSource("source", "name");
+
+		const buffer1 = sourceMapSource.buffer();
+		expect(buffer1.length).toBe(6);
+
+		const buffer2 = sourceMapSource.buffer();
+		expect(buffer2).toBe(buffer1);
+	});
+
+	it("provides buffer when backed by buffer", () => {
+		const sourceMapSource = new SourceMapSource(
+			Buffer.from("source", "utf-8"),
+			"name"
+		);
+
+		const buffer1 = sourceMapSource.buffer();
+		expect(buffer1.length).toBe(6);
+
+		const buffer2 = sourceMapSource.buffer();
+		expect(buffer2).toBe(buffer1);
+	});
 });


### PR DESCRIPTION
The `Source.size` method computes the size from the buffer length,
where the default `Source.buffer` method allocates a new buffer
from the string source. By implementing `SourceMapSource.buffer`
this allocation is avoided, as a buffer representation is available
on the instance. This results in a noticeable performance improvement
for stats computation in Webpack, where chunk sizes are obtained
from `Source.size`.

---

Before:

<img width="1772" alt="Screenshot 2021-05-30 at 01 09 31" src="https://user-images.githubusercontent.com/123679/120086993-671d9300-c0e4-11eb-8c9f-996d77ddb5ca.png">

After:

<img width="312" alt="Screenshot 2021-05-30 at 01 13 55" src="https://user-images.githubusercontent.com/123679/120086994-6ab11a00-c0e4-11eb-944e-d734e54a0f93.png">
