### PR TITLE
Use optional chaning in streamChunksOfCombinedSourceMap.js

### DIFF
--- a/lib/helpers/streamChunksOfCombinedSourceMap.js
+++ b/lib/helpers/streamChunksOfCombinedSourceMap.js
@@ -171,7 +171,7 @@ const streamChunksOfCombinedSourceMap = (
 							if (originalSourceLines !== null) {
 								const name = nameIndexValueMapping[nameIndex];
 								const originalName =
-									innerOriginalLine <= originalSourceLines.length
+									innerOriginalLine <= originalSourceLines?.length
 										? originalSourceLines[innerOriginalLine - 1].slice(
 												innerOriginalColumn,
 												innerOriginalColumn + name.length


### PR DESCRIPTION
This fixed a "Cannot read property 'length' of null" for me when originalSourceLines is null for some reason (happened on require("xlsx") in an electron forge project under Windows).