### PR TITLE
chore: updateHash with string for batching

### DIFF
--- a/lib/OriginalSource.js
+++ b/lib/OriginalSource.js
@@ -15,6 +15,7 @@ class OriginalSource extends Source {
 	constructor(value, name) {
 		super();
 		const isBuffer = Buffer.isBuffer(value);
+		this._valueIsBuffer = isBuffer
 		this._value = isBuffer ? undefined : value;
 		this._valueAsBuffer = isBuffer ? value : undefined;
 		this._name = name;
@@ -124,11 +125,8 @@ class OriginalSource extends Source {
 	}
 
 	updateHash(hash) {
-		if (this._valueAsBuffer === undefined) {
-			this._valueAsBuffer = Buffer.from(this._value, "utf-8");
-		}
 		hash.update("OriginalSource");
-		hash.update(this._valueAsBuffer);
+		hash.update(this._valueIsBuffer ? this._valueAsBuffer : this._value);
 		hash.update(this._name || "");
 	}
 }

--- a/lib/RawSource.js
+++ b/lib/RawSource.js
@@ -70,11 +70,8 @@ class RawSource extends Source {
 	}
 
 	updateHash(hash) {
-		if (this._valueAsBuffer === undefined) {
-			this._valueAsBuffer = Buffer.from(this._value, "utf-8");
-		}
 		hash.update("RawSource");
-		hash.update(this._valueAsBuffer);
+		hash.update(this._valueIsBuffer ? this._valueAsBuffer : this._valueAsString);
 	}
 }
 

--- a/lib/SourceMapSource.js
+++ b/lib/SourceMapSource.js
@@ -20,6 +20,7 @@ class SourceMapSource extends Source {
 	) {
 		super();
 		const valueIsBuffer = Buffer.isBuffer(value);
+		this._valueIsBuffer = valueIsBuffer
 		this._valueAsString = valueIsBuffer ? undefined : value;
 		this._valueAsBuffer = valueIsBuffer ? value : undefined;
 
@@ -28,6 +29,7 @@ class SourceMapSource extends Source {
 		this._hasSourceMap = !!sourceMap;
 		const sourceMapIsBuffer = Buffer.isBuffer(sourceMap);
 		const sourceMapIsString = typeof sourceMap === "string";
+		this._sourceMapIsString = sourceMapIsString
 		this._sourceMapAsObject =
 			sourceMapIsBuffer || sourceMapIsString ? undefined : sourceMap;
 		this._sourceMapAsString = sourceMapIsString ? sourceMap : undefined;
@@ -228,9 +230,9 @@ class SourceMapSource extends Source {
 
 		hash.update("SourceMapSource");
 
-		hash.update(this._valueAsBuffer);
+		hash.update(this._valueIsBuffer ? this._valueAsBuffer : this._valueAsString);
 
-		hash.update(this._sourceMapAsBuffer);
+		hash.update(this._sourceMapIsString ? this._sourceMapAsString : this._sourceMapAsBuffer);
 
 		if (this._hasOriginalSource) {
 			hash.update(this._originalSourceAsBuffer);


### PR DESCRIPTION
String can be buffered for batching updateHash by `BulkUpdateDecorator.prototype.update`. So there is a beneficial performance effect from hashing with string.