### PR TITLE
Avoid regex for lines

### DIFF
--- a/lib/ReplaceSource.js
+++ b/lib/ReplaceSource.js
@@ -269,9 +269,8 @@ class ReplaceSource extends Source {
 						}
 
 						// Insert replacement content splitted into chunks by lines
-						const regexp = /[^\n]+\n?|\n/g;
 						const { content, name } = repls[i];
-						let match = regexp.exec(content);
+						let matches = splitIntoLines(content);
 						let replacementNameIndex = nameIndex;
 						if (sourceIndex >= 0 && name) {
 							let globalIndex = nameMapping.get(name);
@@ -282,8 +281,8 @@ class ReplaceSource extends Source {
 							}
 							replacementNameIndex = globalIndex;
 						}
-						while (match !== null) {
-							const contentLine = match[0];
+						for (let m = 0; m < matches.length; m++) {
+							const contentLine = matches[m];
 							onChunk(
 								contentLine,
 								line,
@@ -300,8 +299,7 @@ class ReplaceSource extends Source {
 							// Only the first chunk has name assigned
 							replacementNameIndex = -1;
 
-							match = regexp.exec(content);
-							if (match === null && !contentLine.endsWith("\n")) {
+							if (m === matches.length - 1 && !contentLine.endsWith("\n")) {
 								if (generatedColumnOffsetLine === line) {
 									generatedColumnOffset += contentLine.length;
 								} else {
@@ -418,10 +416,9 @@ class ReplaceSource extends Source {
 
 		// Insert remaining replacements content splitted into chunks by lines
 		let line = generatedLine + generatedLineOffset;
-		const regexp = /[^\n]+\n?|\n/g;
-		let match = regexp.exec(remainer);
-		while (match !== null) {
-			const contentLine = match[0];
+		let matches = splitIntoLines(remainer);
+		for (let m = 0; m < matches.length; m++) {
+			const contentLine = matches[m];
 			onChunk(
 				contentLine,
 				line,
@@ -433,8 +430,7 @@ class ReplaceSource extends Source {
 				-1
 			);
 
-			match = regexp.exec(remainer);
-			if (match === null && !contentLine.endsWith("\n")) {
+			if (m === matches.length - 1 && !contentLine.endsWith("\n")) {
 				if (generatedColumnOffsetLine === line) {
 					generatedColumnOffset += contentLine.length;
 				} else {


### PR DESCRIPTION
This PR fixes some cases of this issue https://github.com/webpack/webpack-sources/issues/131 

The original issue still existed for our repo. Here is failed [actions](https://github.com/superdispatch/web-ui/runs/4582976070?check_suite_focus=true)

The fix was to avoid regex for other parts of the code.
Here is patch worked for us https://github.com/superdispatch/web-ui/commit/7df2e1f53fe46ed1d400e6fe8cf7bd4523e94c6b