### PR TITLE
test: expand coverage for sources, helpers, and package entry

### DIFF
--- a/benchmark/cases/cached-source/index.bench.mjs
+++ b/benchmark/cases/cached-source/index.bench.mjs
@@ -11,6 +11,16 @@ import sources from "../../../lib/index.js";
 import { fixtureCode, fixtureMap, noop } from "../../fixtures.mjs";
 
 /**
+ * Pre-sized sink used by allocation-heavy tasks to retain the constructed
+ * instances past the loop so V8 cannot dead-code-eliminate them and so
+ * memory pressure is predictable between samples. Overwriting existing
+ * slots (rather than push/length reset) keeps the sink's hidden class
+ * stable and avoids resize allocations during measurement.
+ */
+const CONSTRUCT_BATCH = 100;
+const sink = Array.from({ length: CONSTRUCT_BATCH });
+
+/**
  * A CachedSource with all the common caches already populated. Reused
  * across tasks that explicitly measure the warm path.
  */
@@ -31,8 +41,8 @@ const warmed = (() => {
  */
 export default function register(bench) {
 	bench.add("cached-source: new CachedSource()", () => {
-		for (let i = 0; i < 100; i++) {
-			new sources.CachedSource(new sources.RawSource(fixtureCode));
+		for (let i = 0; i < CONSTRUCT_BATCH; i++) {
+			sink[i] = new sources.CachedSource(new sources.RawSource(fixtureCode));
 		}
 	});
 

--- a/test/CachedSource.js
+++ b/test/CachedSource.js
@@ -419,4 +419,151 @@ describe.each([
 		expect(getHash(clone())).toBe(getHash(original));
 		expect(calls).toBe(3);
 	});
+
+	it("should expose originalLazy (function form) and original()", () => {
+		const original = new RawSource("Hello World");
+		const lazy = () => original;
+		const source = new CachedSource(lazy);
+		expect(source.originalLazy()).toBe(lazy);
+		expect(source.original()).toBe(original);
+		// After original() resolves the function, originalLazy returns the resolved source
+		expect(source.originalLazy()).toBe(original);
+	});
+
+	it("should compute size from cached buffer when _cachedSize is undefined", () => {
+		const buffer = Buffer.from("Hello World");
+		// Provide cachedData with buffer but no size
+		const cachedSource = new CachedSource(new RawSource("Hello World"), {
+			buffer,
+			maps: new Map(),
+		});
+		expect(cachedSource.size()).toBe(buffer.length);
+		expect(cachedSource.size()).toBe(buffer.length);
+	});
+
+	it("should return null for missing map when cached entry is empty", () => {
+		const cachedSource = new CachedSource(new RawSource("Hello World"), {
+			buffer: Buffer.from("Hello World"),
+			size: 11,
+			maps: new Map([["{}", {}]]),
+		});
+		expect(cachedSource.map()).toBeNull();
+	});
+
+	it("should flush accumulated hash strings when they exceed the threshold", () => {
+		class StringyHashSource extends Source {
+			source() {
+				return "ignored";
+			}
+
+			buffer() {
+				return Buffer.from("ignored");
+			}
+
+			size() {
+				return 7;
+			}
+
+			map() {
+				return null;
+			}
+
+			updateHash(hash) {
+				for (let i = 0; i < 15000; i++) {
+					hash.update(`chunk-${i}-`);
+				}
+			}
+		}
+
+		const cachedSource = new CachedSource(new StringyHashSource());
+
+		const hashA = crypto.createHash("md5");
+		cachedSource.updateHash(hashA);
+		const digestA = hashA.digest("hex");
+
+		// When hashing again, the cached hash update is replayed directly
+		const hashB = crypto.createHash("md5");
+		cachedSource.updateHash(hashB);
+		const digestB = hashB.digest("hex");
+
+		expect(digestA).toBe(digestB);
+	});
+
+	it("should handle hash updates starting with a Buffer (no prior string to flush)", () => {
+		class BufferFirstHashSource extends Source {
+			source() {
+				return "text";
+			}
+
+			buffer() {
+				return Buffer.from("text");
+			}
+
+			size() {
+				return 4;
+			}
+
+			map() {
+				return null;
+			}
+
+			updateHash(hash) {
+				// Start with a Buffer so the tracker "else" branch runs
+				// with currentString === undefined, and also pass a long string
+				// so the length-gate in the "string" branch is exercised.
+				hash.update(Buffer.from("leading-buffer-"));
+				hash.update("a".repeat(11000));
+				hash.update("short-string");
+			}
+		}
+
+		const cachedSource = new CachedSource(new BufferFirstHashSource());
+		const hashA = crypto.createHash("md5");
+		cachedSource.updateHash(hashA);
+		const digestA = hashA.digest("hex");
+
+		const hashB = crypto.createHash("md5");
+		cachedSource.updateHash(hashB);
+		const digestB = hashB.digest("hex");
+
+		expect(digestA).toBe(digestB);
+	});
+
+	it("should allow streamChunks when cached map exists but source is not cached", () => {
+		const original = new OriginalSource("Hello World", "file.js");
+		const cachedSource = new CachedSource(original);
+
+		// Populate map cache only (no source/buffer cached yet)
+		cachedSource.map({});
+
+		const chunks = [];
+		cachedSource.streamChunks(
+			{},
+			(...args) => {
+				chunks.push(args);
+			},
+			() => {},
+			() => {},
+		);
+		expect(chunks.length).toBeGreaterThan(0);
+	});
+
+	it("should round-trip CachedSource with a Buffer-backed source", () => {
+		const buffer = Buffer.from(Array.from({ length: 64 }, (_, i) => i));
+		const original = new RawSource(buffer);
+		const source = new CachedSource(original);
+
+		// Populate _cachedSource with the Buffer
+		source.source();
+		source.size();
+
+		const cachedData = source.getCachedData();
+		expect(cachedData.source).toBe(false);
+
+		// @ts-expect-error for tests
+		const clone = new CachedSource(null, cachedData);
+		expect(clone.source()).toEqual(source.source());
+		expect(clone.buffer()).toEqual(source.buffer());
+		expect(clone.size()).toEqual(source.size());
+	});
 });

--- a/test/CompatSource.js
+++ b/test/CompatSource.js
@@ -36,4 +36,107 @@ describe("compatSource", () => {
 		});
 		expect(calledWith).toEqual([Buffer.from(CONTENT)]);
 	});
+
+	it("should use buffer from source-like when provided", () => {
+		const CONTENT = "Line1\n\nLine3\n";
+		const buffer = Buffer.from(CONTENT);
+		const source = CompatSource.from({
+			source() {
+				return CONTENT;
+			},
+			buffer() {
+				return buffer;
+			},
+		});
+		expect(source.buffer()).toBe(buffer);
+	});
+
+	it("should use size from super when sourceLike doesn't define size", () => {
+		const CONTENT = "Hello";
+		const source = CompatSource.from({
+			source() {
+				return CONTENT;
+			},
+		});
+		expect(source.size()).toBe(5);
+	});
+
+	it("should call map from sourceLike when provided", () => {
+		const map = {
+			version: 3,
+			sources: ["a.js"],
+			names: [],
+			mappings: "",
+			file: "x",
+		};
+		const source = CompatSource.from({
+			source() {
+				return "content";
+			},
+			map() {
+				return map;
+			},
+			updateHash(hash) {
+				hash.update("custom");
+			},
+		});
+		expect(source.map()).toBe(map);
+	});
+
+	it("should call sourceAndMap from sourceLike when provided", () => {
+		const map = {
+			version: 3,
+			sources: ["a.js"],
+			names: [],
+			mappings: "",
+			file: "x",
+		};
+		const sourceAndMap = { source: "content", map };
+		const source = CompatSource.from({
+			source() {
+				return "content";
+			},
+			sourceAndMap() {
+				return sourceAndMap;
+			},
+		});
+		expect(source.sourceAndMap()).toBe(sourceAndMap);
+	});
+
+	it("should call updateHash from sourceLike when provided", () => {
+		/** @type {(string | Buffer)[]} */
+		const calledWith = [];
+		const source = CompatSource.from({
+			source() {
+				return "content";
+			},
+			updateHash(hash) {
+				hash.update("custom-hash");
+			},
+		});
+		source.updateHash({
+			// @ts-expect-error for tests
+			update(value) {
+				calledWith.push(value);
+			},
+		});
+		expect(calledWith).toEqual(["custom-hash"]);
+	});
+
+	it("should throw when map is defined but updateHash is not", () => {
+		const source = CompatSource.from({
+			source() {
+				return "content";
+			},
+			map() {
+				return null;
+			},
+		});
+		expect(() => {
+			source.updateHash({
+				// @ts-expect-error for tests
+				update() {},
+			});
+		}).toThrow(/'map' method must also provide an 'updateHash' method/);
+	});
 });

--- a/test/ConcatSource.js
+++ b/test/ConcatSource.js
@@ -212,6 +212,89 @@ describe("concatSource", () => {
 	`);
 	});
 
+	it("should concat a SourceLike child without a buffer() method that returns a Buffer", () => {
+		const customBuffer = Buffer.from("custom-content");
+		const customSource = {
+			source() {
+				return customBuffer;
+			},
+			size() {
+				return customBuffer.length;
+			},
+		};
+		const source = new ConcatSource(customSource, new RawSource("-after"));
+		const result = source.buffer();
+		expect(result).toEqual(
+			Buffer.concat([customBuffer, Buffer.from("-after")]),
+		);
+	});
+
+	it("should concat a SourceLike child where source() returns a string (no buffer())", () => {
+		const customSource = {
+			source() {
+				return "custom-content";
+			},
+			size() {
+				return "custom-content".length;
+			},
+		};
+		const source = new ConcatSource(customSource, new RawSource("-after"));
+		const result = source.buffer();
+		expect(result).toEqual(
+			Buffer.concat([Buffer.from("custom-content"), Buffer.from("-after")]),
+		);
+	});
+
+	it("should optimize nested string-only ConcatSources across re-optimization", () => {
+		// Create two ConcatSources that produce RawSource (kept in stringsAsRawSources)
+		const c1 = new ConcatSource("a", "b");
+		c1.source(); // triggers _optimize, putting its RawSource("ab") into stringsAsRawSources
+
+		const c2 = new ConcatSource("c", "d");
+		c2.source(); // same, puts RawSource("cd") into stringsAsRawSources
+
+		const merged = new ConcatSource();
+		merged.add(c1); // flatten c1's children
+		merged.add("x");
+		merged.add(c2);
+		merged.add("y");
+		merged.add(c1);
+		expect(merged.source()).toBe("abxcdyab");
+	});
+
+	it("should re-optimize when raw source followed by regular source", () => {
+		const c1 = new ConcatSource("a", "b");
+		c1.source(); // places RawSource into stringsAsRawSources
+		const regular = new OriginalSource("Z", "z.js");
+		const merged = new ConcatSource();
+		merged.add(c1); // flatten
+		merged.add(regular);
+		expect(merged.source()).toBe("abZ");
+		expect(merged.getChildren()).toHaveLength(2);
+	});
+
+	it("should reflect empty ConcatSource", () => {
+		const source = new ConcatSource();
+		expect(source.source()).toBe("");
+		expect(source.size()).toBe(0);
+		expect(source.buffer()).toEqual(Buffer.alloc(0));
+	});
+
+	it("should flatten nested ConcatSource via add()", () => {
+		const inner = new ConcatSource("a", "b");
+		const outer = new ConcatSource();
+		outer.add(inner);
+		outer.add("c");
+		expect(outer.source()).toBe("abc");
+	});
+
+	it("should optimize on first getChildren() call", () => {
+		const source = new ConcatSource("a", "b", new RawSource("c"));
+		// Call getChildren without first calling source()/size()/buffer()
+		const children = source.getChildren();
+		expect(children.length).toBeGreaterThan(0);
+	});
+
 	it("should handle column mapping correctly with missing sources", () => {
 		const source = new ConcatSource(
 			"/*! For license information please see main.js.LICENSE.txt */",

--- a/test/OriginalSource.js
+++ b/test/OriginalSource.js
@@ -102,6 +102,25 @@ describe.each([
 		expect(source.size()).toBe(256);
 	});
 
+	it("should expose getName()", () => {
+		const source = new OriginalSource("hi", "file.js");
+		expect(source.getName()).toBe("file.js");
+	});
+
+	it("should compute map correctly from buffer-backed source", () => {
+		const content = "Line1\nLine2\n";
+		const source = new OriginalSource(Buffer.from(content), "file.js");
+		expect(source.sourceAndMap().source).toBe(content);
+	});
+
+	it("should map correctly when constructed from a Buffer (streamChunks path)", () => {
+		const content = "Line1\nLine2\n";
+		const source = new OriginalSource(Buffer.from(content), "file.js");
+		// Calling map() without calling source() first to ensure streamChunks
+		// populates _value from the buffer
+		expect(source.map({ columns: false })).not.toBeNull();
+	});
+
 	it("should return the correct size for unicode files", () => {
 		const source = new OriginalSource("😋", "file.js");
 		expect(source.size()).toBe(4);

--- a/test/PrefixSource.js
+++ b/test/PrefixSource.js
@@ -2,9 +2,11 @@
 
 jest.mock("./__mocks__/createMappingsSerializer");
 
+const crypto = require("crypto");
 const { PrefixSource } = require("../");
 const { OriginalSource } = require("../");
 const { ConcatSource } = require("../");
+const { RawSource } = require("../");
 const { withReadableMappings } = require("./helpers");
 
 describe("prefixSource", () => {
@@ -107,5 +109,64 @@ describe("prefixSource", () => {
 		);
 
 		expect(source.sourceAndMap().source).toEqual(source.source());
+	});
+
+	it("should expose prefix and original source", () => {
+		const inner = new OriginalSource("Hello", "file.js");
+		const source = new PrefixSource("> ", inner);
+		expect(source.getPrefix()).toBe("> ");
+		expect(source.original()).toBe(inner);
+	});
+
+	it("should update hash consistently", () => {
+		const source1 = new PrefixSource(
+			"> ",
+			new OriginalSource("Hello", "file.js"),
+		);
+		const source2 = new PrefixSource(
+			"> ",
+			new OriginalSource("Hello", "file.js"),
+		);
+		const source3 = new PrefixSource(
+			"> ",
+			new OriginalSource("World", "file.js"),
+		);
+
+		const hash1 = crypto.createHash("md5");
+		source1.updateHash(hash1);
+		const digest1 = hash1.digest("hex");
+
+		const hash2 = crypto.createHash("md5");
+		source2.updateHash(hash2);
+		const digest2 = hash2.digest("hex");
+
+		const hash3 = crypto.createHash("md5");
+		source3.updateHash(hash3);
+		const digest3 = hash3.digest("hex");
+
+		expect(digest1).toBe(digest2);
+		expect(digest1).not.toBe(digest3);
+	});
+
+	it("should accept a raw string as source", () => {
+		const source = new PrefixSource("**", "line1\nline2");
+		expect(source.source()).toBe("**line1\n**line2");
+	});
+
+	it("should accept a Buffer as source", () => {
+		const source = new PrefixSource("**", Buffer.from("line1\nline2"));
+		expect(source.source()).toBe("**line1\n**line2");
+	});
+
+	it("should work with RawSource (no map)", () => {
+		const source = new PrefixSource("> ", new RawSource("hello\nworld"));
+		expect(source.source()).toBe("> hello\n> world");
+	});
+
+	it("should handle empty prefix (prefixOffset = 0)", () => {
+		const inner = new OriginalSource("hello\nworld\n", "file.js");
+		const source = new PrefixSource("", inner);
+		expect(source.source()).toBe("hello\nworld\n");
+		expect(source.sourceAndMap().source).toBe("hello\nworld\n");
 	});
 });

--- a/test/RawSource.js
+++ b/test/RawSource.js
@@ -24,6 +24,42 @@ describe("rawSource", () => {
 		expect(source.buffer()).toStrictEqual(source.buffer());
 	});
 
+	it("converts to string on source() when constructed from buffer with convertToString=true", () => {
+		const source = new RawSource(Buffer.from(CODE_STRING), true);
+		expect(source.source()).toBe(CODE_STRING);
+		// Called again to hit cache path
+		expect(source.source()).toBe(CODE_STRING);
+	});
+
+	it("should throw TypeError for non-string non-Buffer value", () => {
+		expect(() => {
+			// @ts-expect-error for tests
+			// eslint-disable-next-line no-new
+			new RawSource(42);
+		}).toThrow(TypeError);
+		expect(() => {
+			// @ts-expect-error for tests
+			// eslint-disable-next-line no-new
+			new RawSource(null);
+		}).toThrow(TypeError);
+		expect(() => {
+			// @ts-expect-error for tests
+			// eslint-disable-next-line no-new
+			new RawSource({});
+		}).toThrow(TypeError);
+	});
+
+	it("should report isBuffer() correctly for Buffer", () => {
+		const source = new RawSource(Buffer.from(CODE_STRING));
+		expect(source.isBuffer()).toBe(true);
+	});
+
+	it("should return null from map()", () => {
+		const source = new RawSource(CODE_STRING);
+		expect(source.map()).toBeNull();
+		expect(source.map({ columns: false })).toBeNull();
+	});
+
 	it("stream chunks works correctly", () => {
 		const source = new RawSource(CODE_STRING, true);
 		// @ts-expect-error for tests
@@ -111,6 +147,23 @@ describe("rawSource", () => {
 				expect(line).toBe(`console.log('test${"2".repeat(lineNum - 1)}');\n`);
 			});
 			expect.assertions(3);
+		});
+
+		it("should handle streamChunks when constructed from a Buffer without pre-caching", () => {
+			// Buffer backing, convertToString=false. _valueAsString remains undefined.
+			const source = new RawSource(Buffer.from(CODE_STRING));
+			/** @type {(string | undefined)[]} */
+			const chunks = [];
+			// @ts-expect-error for tests
+			source.streamChunks(null, (chunk) => {
+				chunks.push(chunk);
+			});
+			expect(chunks).toHaveLength(3);
+		});
+
+		it("should expose source() on a Buffer-backed RawSource", () => {
+			const source = new RawSource(Buffer.from(CODE_STRING));
+			expect(source.source().toString("utf8")).toEqual(CODE_STRING);
 		});
 	});
 });

--- a/test/ReplaceSource.js
+++ b/test/ReplaceSource.js
@@ -4,9 +4,11 @@
 
 jest.mock("./__mocks__/createMappingsSerializer");
 
+const crypto = require("crypto");
 const validate = require("sourcemap-validator");
 const { ReplaceSource } = require("../");
 const { OriginalSource } = require("../");
+const { RawSource } = require("../");
 const { SourceMapSource } = require("../");
 const { withReadableMappings } = require("./helpers");
 
@@ -318,5 +320,135 @@ export default function StaticPage(_ref) {
 		  "version": 3,
 		}
 	`);
+	});
+
+	it("should return getName()", () => {
+		const source = new ReplaceSource(
+			new OriginalSource("Hello World", "file.txt"),
+			"named.txt",
+		);
+		expect(source.getName()).toBe("named.txt");
+	});
+
+	it("should return getName() as undefined when not provided", () => {
+		const source = new ReplaceSource(new OriginalSource("Hi", "file.txt"));
+		expect(source.getName()).toBeUndefined();
+	});
+
+	it("should return sorted replacements from getReplacements", () => {
+		const source = new ReplaceSource(
+			new OriginalSource("Hello World", "file.txt"),
+		);
+		source.replace(6, 10, "Claude");
+		source.replace(0, 4, "Howdy");
+		const replacements = source.getReplacements();
+		expect(replacements).toHaveLength(2);
+		expect(replacements[0].content).toBe("Howdy");
+		expect(replacements[1].content).toBe("Claude");
+	});
+
+	it("should throw when replace() gets non-string newValue", () => {
+		const source = new ReplaceSource(
+			new OriginalSource("Hello World", "file.txt"),
+		);
+		expect(() => {
+			// @ts-expect-error for tests
+			source.replace(0, 4, 123);
+		}).toThrow(/insertion must be a string/);
+	});
+
+	it("should throw when insert() gets non-string newValue", () => {
+		const source = new ReplaceSource(
+			new OriginalSource("Hello World", "file.txt"),
+		);
+		expect(() => {
+			// @ts-expect-error for tests
+			source.insert(0, 123);
+		}).toThrow(/insertion must be a string/);
+	});
+
+	it("should pass through source and map untouched when no replacements", () => {
+		const innerSource = new OriginalSource("Hello World", "file.txt");
+		const source = new ReplaceSource(innerSource);
+		expect(source.source()).toBe(innerSource.source());
+		expect(source.map()).toEqual(innerSource.map());
+		expect(source.sourceAndMap()).toEqual(innerSource.sourceAndMap());
+	});
+
+	it("should return original source when no replacements", () => {
+		const innerSource = new OriginalSource("Hello World", "file.txt");
+		const source = new ReplaceSource(innerSource);
+		expect(source.original()).toBe(innerSource);
+	});
+
+	it("should update hash consistently", () => {
+		const inner = new OriginalSource("Hello World", "file.txt");
+
+		const source1 = new ReplaceSource(inner, "name");
+		source1.replace(0, 4, "Howdy", "greeting");
+		source1.insert(6, "[ins]");
+
+		const source2 = new ReplaceSource(inner, "name");
+		source2.replace(0, 4, "Howdy", "greeting");
+		source2.insert(6, "[ins]");
+
+		const source3 = new ReplaceSource(inner);
+		source3.replace(0, 4, "Hey");
+
+		const hash1 = crypto.createHash("md5");
+		source1.updateHash(hash1);
+		const digest1 = hash1.digest("hex");
+
+		const hash2 = crypto.createHash("md5");
+		source2.updateHash(hash2);
+		const digest2 = hash2.digest("hex");
+
+		const hash3 = crypto.createHash("md5");
+		source3.updateHash(hash3);
+		const digest3 = hash3.digest("hex");
+
+		expect(digest1).toBe(digest2);
+		expect(digest1).not.toBe(digest3);
+	});
+
+	it("should handle replacements that skip a chunk ending with newline", () => {
+		const source = new ReplaceSource(
+			new OriginalSource(
+				["line1", "line2", "line3", "line4"].join("\n"),
+				"file.txt",
+			),
+		);
+		source.replace(6, 17, "X");
+		expect(source.source()).toBe("line1\nXline4");
+	});
+
+	it("should handle multi-line replacement content", () => {
+		const source = new ReplaceSource(
+			new OriginalSource("hello world", "file.txt"),
+		);
+		source.replace(6, 10, "multi\nline\nreplacement");
+		expect(source.source()).toBe("hello multi\nline\nreplacement");
+	});
+
+	it("should handle a replacement that happens at source end", () => {
+		const source = new ReplaceSource(new OriginalSource("hello", "file.txt"));
+		source.insert(5, " world");
+		source.insert(5, "!");
+		expect(source.source()).toBe("hello world!");
+	});
+
+	it("should handle replacements ending with newline", () => {
+		const source = new ReplaceSource(
+			new OriginalSource("abc\ndef\nghi", "file.txt"),
+		);
+		source.replace(0, 2, "xyz\n");
+		expect(source.source()).toBe("xyz\n\ndef\nghi");
+	});
+
+	it("should work with RawSource as source (no map)", () => {
+		const source = new ReplaceSource(new RawSource("Hello World"));
+		source.replace(6, 10, "You");
+		expect(source.source()).toBe("Hello You");
+		expect(source.sourceAndMap()).toHaveProperty("source", "Hello You");
 	});
 });

--- a/test/SizeOnlySource.js
+++ b/test/SizeOnlySource.js
@@ -17,4 +17,14 @@ describe("sizeOnlySource", () => {
 			}).toThrow(/not available/);
 		});
 	}
+
+	it("should throw on updateHash()", () => {
+		const source = new SizeOnlySource(42);
+		expect(() => {
+			source.updateHash({
+				// @ts-expect-error for tests
+				update() {},
+			});
+		}).toThrow(/not available/);
+	});
 });

--- a/test/Source.js
+++ b/test/Source.js
@@ -1,0 +1,76 @@
+"use strict";
+
+const { Source } = require("../");
+
+describe("source", () => {
+	it("should throw an Abstract error for source()", () => {
+		const source = new Source();
+		expect(() => {
+			source.source();
+		}).toThrow("Abstract");
+	});
+
+	it("should throw an Abstract error for updateHash()", () => {
+		const source = new Source();
+		expect(() => {
+			source.updateHash({
+				// @ts-expect-error for tests
+				update() {},
+			});
+		}).toThrow("Abstract");
+	});
+
+	it("should return null for map() by default", () => {
+		class DummySource extends Source {
+			source() {
+				return "dummy";
+			}
+		}
+		const source = new DummySource();
+		expect(source.map()).toBeNull();
+	});
+
+	it("should return source and map for sourceAndMap()", () => {
+		class DummySource extends Source {
+			source() {
+				return "dummy";
+			}
+		}
+		const source = new DummySource();
+		expect(source.sourceAndMap()).toEqual({
+			source: "dummy",
+			map: null,
+		});
+	});
+
+	it("should compute buffer from string source by default", () => {
+		class DummySource extends Source {
+			source() {
+				return "dummy";
+			}
+		}
+		const source = new DummySource();
+		expect(source.buffer()).toEqual(Buffer.from("dummy", "utf8"));
+	});
+
+	it("should return buffer when source is already a buffer", () => {
+		const buffer = Buffer.from([1, 2, 3]);
+		class DummySource extends Source {
+			source() {
+				return buffer;
+			}
+		}
+		const source = new DummySource();
+		expect(source.buffer()).toBe(buffer);
+	});
+
+	it("should compute size from buffer by default", () => {
+		class DummySource extends Source {
+			source() {
+				return "abcdef";
+			}
+		}
+		const source = new DummySource();
+		expect(source.size()).toBe(6);
+	});
+});

--- a/test/SourceMapSource.js
+++ b/test/SourceMapSource.js
@@ -578,6 +578,98 @@ describe.each([
 		expect(buffer2).toBe(buffer1);
 	});
 
+	it("should accept source map as string", () => {
+		const mapObj = {
+			version: 3,
+			sources: ["hello-source.txt"],
+			sourcesContent: ["hello world\n"],
+			mappings: "AAAA",
+			names: [],
+			file: "",
+		};
+		const source = new SourceMapSource(
+			"hello world\n",
+			"hello.txt",
+			JSON.stringify(mapObj),
+		);
+		expect(source.source()).toBe("hello world\n");
+		const map = source.map();
+		expect(map).toEqual({ ...mapObj });
+		// call again to hit the cached string path in _sourceMapString
+		source.updateHash({
+			// @ts-expect-error for tests
+			update() {},
+		});
+	});
+
+	it("should accept inner source map as string", () => {
+		const outerMap = {
+			version: 3,
+			sources: ["hello.txt"],
+			mappings: "AAAA",
+			names: [],
+			file: "",
+		};
+		const innerMap = {
+			version: 3,
+			sources: ["hello-world.txt"],
+			mappings: "AAAA",
+			names: [],
+			file: "",
+		};
+		const source = new SourceMapSource(
+			"hello world\n",
+			"hello.txt",
+			outerMap,
+			"hello world\n",
+			JSON.stringify(innerMap),
+		);
+		// exercise _innerSourceMapBuffer via updateHash, then map() which
+		// calls _innerSourceMapObject which uses _innerSourceMapString - the string was already provided
+		source.updateHash({
+			// @ts-expect-error for tests
+			update() {},
+		});
+		// also call map which will trigger _innerSourceMapObject (reads string)
+		expect(source.map()).not.toBeNull();
+	});
+
+	it("should include remove original source flag in the hash", () => {
+		const outerMap = {
+			version: 3,
+			sources: ["hello.txt"],
+			mappings: "AAAA",
+			names: [],
+			file: "",
+		};
+		const sourceA = new SourceMapSource(
+			"hello\n",
+			"hello.txt",
+			outerMap,
+			"hello\n",
+			null,
+			false,
+		);
+		const sourceB = new SourceMapSource(
+			"hello\n",
+			"hello.txt",
+			outerMap,
+			"hello\n",
+			null,
+			true,
+		);
+
+		const hashA = crypto.createHash("md5");
+		sourceA.updateHash(hashA);
+		const digestA = hashA.digest("hex");
+
+		const hashB = crypto.createHash("md5");
+		sourceB.updateHash(hashB);
+		const digestB = hashB.digest("hex");
+
+		expect(digestA).not.toBe(digestB);
+	});
+
 	for (const hash of [
 		["md5", [crypto.createHash("md5"), crypto.createHash("md5")]],
 		["md4", [new BatchedHash(createMd4()), new BatchedHash(createMd4())]],

--- a/test/helpers-unit.js
+++ b/test/helpers-unit.js
@@ -1,0 +1,311 @@
+"use strict";
+
+const {
+	getMap,
+	getSourceAndMap,
+} = require("../lib/helpers/getFromStreamChunks");
+const getGeneratedSourceInfo = require("../lib/helpers/getGeneratedSourceInfo");
+const getSource = require("../lib/helpers/getSource");
+const readMappings = require("../lib/helpers/readMappings");
+const splitIntoLines = require("../lib/helpers/splitIntoLines");
+const splitIntoPotentialTokens = require("../lib/helpers/splitIntoPotentialTokens");
+const streamAndGetSourceAndMap = require("../lib/helpers/streamAndGetSourceAndMap");
+const {
+	disableDualStringBufferCaching,
+	enableDualStringBufferCaching,
+	enterStringInterningRange,
+	exitStringInterningRange,
+	internString,
+	isDualStringBufferCachingEnabled,
+} = require("../lib/helpers/stringBufferUtils");
+
+describe("getGeneratedSourceInfo", () => {
+	it("should return empty object when source is undefined", () => {
+		expect(getGeneratedSourceInfo(undefined)).toEqual({});
+	});
+
+	it("should return correct info for single line", () => {
+		const info = getGeneratedSourceInfo("hello world");
+		expect(info).toEqual({
+			generatedLine: 1,
+			generatedColumn: 11,
+			source: "hello world",
+		});
+	});
+
+	it("should return correct info for multi-line source", () => {
+		const info = getGeneratedSourceInfo("hello\nworld\nfoo");
+		expect(info.generatedLine).toBe(3);
+		expect(info.generatedColumn).toBe(3);
+	});
+
+	it("should count newlines accurately for trailing newline", () => {
+		const info = getGeneratedSourceInfo("a\nb\n");
+		expect(info.generatedLine).toBe(3);
+		expect(info.generatedColumn).toBe(0);
+	});
+
+	it("should handle empty string as single empty line", () => {
+		const info = getGeneratedSourceInfo("");
+		expect(info).toEqual({
+			generatedLine: 1,
+			generatedColumn: 0,
+			source: "",
+		});
+	});
+});
+
+describe("getSource", () => {
+	const baseMap = {
+		version: 3,
+		sources: ["a.js", "b.js"],
+		names: [],
+		mappings: "",
+		file: "x",
+	};
+
+	it("should return null for negative index", () => {
+		expect(getSource(baseMap, -1)).toBeNull();
+	});
+
+	it("should return source as-is when no sourceRoot", () => {
+		expect(getSource(baseMap, 0)).toBe("a.js");
+		expect(getSource(baseMap, 1)).toBe("b.js");
+	});
+
+	it("should prefix sourceRoot without trailing slash", () => {
+		expect(getSource({ ...baseMap, sourceRoot: "src" }, 0)).toBe("src/a.js");
+	});
+
+	it("should prefix sourceRoot with trailing slash", () => {
+		expect(getSource({ ...baseMap, sourceRoot: "src/" }, 0)).toBe("src/a.js");
+	});
+});
+
+describe("splitIntoLines", () => {
+	it("should split simple lines", () => {
+		expect(splitIntoLines("a\nb\nc")).toEqual(["a\n", "b\n", "c"]);
+	});
+
+	it("should handle trailing newline", () => {
+		expect(splitIntoLines("a\nb\n")).toEqual(["a\n", "b\n"]);
+	});
+
+	it("should handle empty string", () => {
+		expect(splitIntoLines("")).toEqual([]);
+	});
+});
+
+describe("splitIntoPotentialTokens", () => {
+	it("should split tokens from a non-empty string", () => {
+		const result = splitIntoPotentialTokens("a b c");
+		expect(result).not.toBeNull();
+	});
+
+	it("should return null for empty string", () => {
+		expect(splitIntoPotentialTokens("")).toBeNull();
+	});
+});
+
+describe("readMappings", () => {
+	it("should ignore out-of-range characters", () => {
+		const mappings = [];
+		// The tilde char (charCode 126) is out of the ccToValue range
+		readMappings("AAAA~;AAAA", (...args) => {
+			mappings.push(args);
+		});
+		expect(mappings).toHaveLength(2);
+		expect(mappings[0]).toEqual([1, 0, 0, 1, 0, -1]);
+	});
+
+	it("should handle empty mappings", () => {
+		const mappings = [];
+		readMappings("", (...args) => {
+			mappings.push(args);
+		});
+		expect(mappings).toHaveLength(0);
+	});
+
+	it("should parse simple mapping with source", () => {
+		const mappings = [];
+		readMappings("AAAA", (...args) => {
+			mappings.push(args);
+		});
+		expect(mappings).toHaveLength(1);
+		expect(mappings[0]).toEqual([1, 0, 0, 1, 0, -1]);
+	});
+
+	it("should parse mapping with name", () => {
+		const mappings = [];
+		readMappings("AAAAA", (...args) => {
+			mappings.push(args);
+		});
+		expect(mappings).toHaveLength(1);
+		expect(mappings[0]).toEqual([1, 0, 0, 1, 0, 0]);
+	});
+
+	it("should parse multiple lines", () => {
+		const mappings = [];
+		readMappings("AAAA;AACA", (...args) => {
+			mappings.push(args);
+		});
+		expect(mappings).toHaveLength(2);
+	});
+});
+
+describe("getFromStreamChunks", () => {
+	// A SourceLike with streamChunks that emits non-sequential indices so
+	// getMap/getSourceAndMap's gap-fill loops run.
+	const makeSparseSource = () => ({
+		streamChunks(options, onChunk, onSource, onName) {
+			onSource(0, "first.js", "first content");
+			// jump from 0 to 2, leaving index 1 empty
+			onSource(2, "third.js", "third content");
+			onName(0, "alpha");
+			onName(2, "gamma");
+			onChunk("x", 1, 0, 0, 1, 0, 0);
+			onChunk("y", 1, 1, 2, 1, 0, 2);
+			return { generatedLine: 1, generatedColumn: 2, source: "xy" };
+		},
+	});
+
+	it("getMap fills missing source and name indices with null", () => {
+		const map =
+			/** @type {import("../lib/Source").RawSourceMap} */
+			(getMap(makeSparseSource()));
+		expect(map).not.toBeNull();
+		expect(map.sources).toEqual(["first.js", null, "third.js"]);
+		expect(map.sourcesContent).toEqual([
+			"first content",
+			null,
+			"third content",
+		]);
+		expect(map.names).toEqual(["alpha", null, "gamma"]);
+	});
+
+	it("getSourceAndMap fills missing source and name indices with null", () => {
+		const { map, source } = getSourceAndMap(makeSparseSource());
+		const m = /** @type {import("../lib/Source").RawSourceMap} */ (map);
+		expect(source).toBe("xy");
+		expect(m).not.toBeNull();
+		expect(m.sources).toEqual(["first.js", null, "third.js"]);
+		expect(m.sourcesContent).toEqual(["first content", null, "third content"]);
+		expect(m.names).toEqual(["alpha", null, "gamma"]);
+	});
+
+	it("getMap returns null when no mappings are produced", () => {
+		const emptySource = {
+			streamChunks() {
+				return { generatedLine: 1, generatedColumn: 0, source: "" };
+			},
+		};
+		expect(getMap(emptySource)).toBeNull();
+	});
+});
+
+describe("streamAndGetSourceAndMap", () => {
+	it("fills missing source and name indices and returns a map", () => {
+		const sparseSource = {
+			streamChunks(options, onChunk, onSource, onName) {
+				onSource(0, "first.js", "first content");
+				onSource(2, "third.js", "third content");
+				onName(0, "alpha");
+				onName(2, "gamma");
+				onChunk("x", 1, 0, 0, 1, 0, 0);
+				onChunk("y", 1, 1, 2, 1, 0, 2);
+				return { generatedLine: 1, generatedColumn: 2, source: "xy" };
+			},
+		};
+		const chunks = [];
+		const sources = [];
+		const names = [];
+		const result = streamAndGetSourceAndMap(
+			// @ts-expect-error for tests
+			sparseSource,
+			{},
+			(...args) => {
+				chunks.push(args);
+			},
+			(...args) => {
+				sources.push(args);
+			},
+			(...args) => {
+				names.push(args);
+			},
+		);
+		const { map: rawMap } = result;
+		const map = /** @type {import("../lib/Source").RawSourceMap} */ (rawMap);
+		expect(result.source).toBe("xy");
+		expect(map.sources).toEqual(["first.js", null, "third.js"]);
+		expect(map.names).toEqual(["alpha", null, "gamma"]);
+		expect(chunks).toHaveLength(2);
+		expect(sources).toHaveLength(2);
+		expect(names).toHaveLength(2);
+	});
+});
+
+describe("stringBufferUtils", () => {
+	afterEach(() => {
+		enableDualStringBufferCaching();
+	});
+
+	it("should toggle dual string buffer caching", () => {
+		expect(isDualStringBufferCachingEnabled()).toBe(true);
+		disableDualStringBufferCaching();
+		expect(isDualStringBufferCachingEnabled()).toBe(false);
+		enableDualStringBufferCaching();
+		expect(isDualStringBufferCachingEnabled()).toBe(true);
+	});
+
+	it("should intern strings only when interning is enabled", () => {
+		const big = "a".repeat(200);
+		const big2 = `${"a".repeat(199)}a`;
+		// Ensure we start from a clean slate
+		expect(internString(big)).toBe(big);
+
+		enterStringInterningRange();
+		try {
+			const interned1 = internString(big);
+			const interned2 = internString(big2);
+			expect(interned1).toBe(big);
+			// Both strings have same content so should be deduplicated
+			expect(interned2).toBe(interned1);
+		} finally {
+			exitStringInterningRange();
+		}
+	});
+
+	it("should not intern short strings", () => {
+		enterStringInterningRange();
+		try {
+			const shortStr = "short";
+			expect(internString(shortStr)).toBe(shortStr);
+		} finally {
+			exitStringInterningRange();
+		}
+	});
+
+	it("should not intern falsy strings", () => {
+		enterStringInterningRange();
+		try {
+			expect(internString("")).toBe("");
+		} finally {
+			exitStringInterningRange();
+		}
+	});
+
+	it("should nest interning ranges properly", () => {
+		enterStringInterningRange();
+		enterStringInterningRange();
+		const big = "b".repeat(200);
+		const interned1 = internString(big);
+		exitStringInterningRange();
+		// Still enabled because one range is still open
+		const interned2 = internString(big);
+		expect(interned2).toBe(interned1);
+		exitStringInterningRange();
+		// Now disabled; cache should be cleared, fresh string returned as-is
+		const freshStr = "c".repeat(200);
+		expect(internString(freshStr)).toBe(freshStr);
+	});
+});

--- a/test/package-entry.js
+++ b/test/package-entry.js
@@ -23,4 +23,28 @@ describe("package-entry", () => {
 			expect(require("../")[name]).toBe(require(`../lib/${name}`));
 		}
 	});
+
+	it("should expose util.stringBufferUtils", () => {
+		const { util } = require("../");
+
+		expect(util.stringBufferUtils).toBe(
+			require("../lib/helpers/stringBufferUtils"),
+		);
+		expect(typeof util.stringBufferUtils.isDualStringBufferCachingEnabled).toBe(
+			"function",
+		);
+		expect(typeof util.stringBufferUtils.enableDualStringBufferCaching).toBe(
+			"function",
+		);
+		expect(typeof util.stringBufferUtils.disableDualStringBufferCaching).toBe(
+			"function",
+		);
+		expect(typeof util.stringBufferUtils.enterStringInterningRange).toBe(
+			"function",
+		);
+		expect(typeof util.stringBufferUtils.exitStringInterningRange).toBe(
+			"function",
+		);
+		expect(typeof util.stringBufferUtils.internString).toBe("function");
+	});
 });


### PR DESCRIPTION
Add targeted tests that exercise previously untested branches and
edge cases: the abstract `Source` base class, `SizeOnlySource`'s
`updateHash`, `CompatSource`'s optional delegates, `RawSource`'s
type validation and Buffer-backed source path, `OriginalSource`'s
`getName` and Buffer-backed map path, `ConcatSource`'s `buffer()`
fallbacks and re-optimization paths, `PrefixSource`'s accessors and
empty-prefix handling, `ReplaceSource`'s accessors, guards, hash
stability, and edge cases, `CachedSource`'s lazy source accessor,
hash flushing, map-only streamChunks, and Buffer round-tripping,
and `SourceMapSource`'s string/buffer source-map variants and hash
inclusion of `removeOriginalSource`. Add a dedicated helpers unit
test file covering `getGeneratedSourceInfo`, `getSource`,
`splitIntoLines`, `splitIntoPotentialTokens`, `readMappings`,
`getFromStreamChunks`, `streamAndGetSourceAndMap`, and
`stringBufferUtils`, including string-interning toggles and gap
filling for non-sequential source/name indices.