### PR TITLE
feat: add buffers() method returning Buffer[]

### DIFF
--- a/.changeset/buffers-method.md
+++ b/.changeset/buffers-method.md
@@ -1,0 +1,5 @@
+---
+"webpack-sources": minor
+---
+
+Add `Source.prototype.buffers()` that returns the source as `Buffer[]`. `ConcatSource`, `CachedSource`, and `CompatSource` implement it without allocating an intermediate concatenated buffer, allowing consumers that can write multiple buffers at once (e.g. via `writev`) to avoid the overhead of `Buffer.concat` in deeply nested sources.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ Source.prototype.buffer() -> Buffer
 
 Returns the represented source code as Buffer. Strings are converted to utf-8.
 
+#### `buffers`
+
+<!-- eslint-skip -->
+```typescript
+Source.prototype.buffers() -> Buffer[]
+```
+
+Returns the represented source code as an array of Buffers. This avoids the
+intermediate `Buffer.concat` allocation performed by `buffer()` when the source
+is composed of multiple children (for example `ConcatSource`). Consumers that
+can accept an array of buffers (e.g. writing via `fs.createWriteStream` or
+`writev`) should prefer this method for better performance.
+
+The default implementation returns `[this.buffer()]`.
+
 #### `size`
 
 <!-- eslint-skip -->

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -112,7 +112,7 @@ stable than per-call timing for sub-microsecond work.
 
 | Case                              | What it measures                                                              |
 | --------------------------------- | ----------------------------------------------------------------------------- |
-| `realistic-source-map-pipeline`   | OriginalSource -> ReplaceSource -> ConcatSource -> CachedSource (cold + warm) |
+| `realistic-source-map-pipeline`   | OriginalSource -> ReplaceSource -> ConcatSource -> CachedSource (cold + warm); also `buffer()` vs `buffers()` over the `CachedSource -> ConcatSource -> CachedSource -> ConcatSource` layering from issue #157 |
 
 ## Adding a new case
 

--- a/benchmark/cases/cached-source/index.bench.mjs
+++ b/benchmark/cases/cached-source/index.bench.mjs
@@ -4,27 +4,26 @@
  * Two axes matter for CachedSource: cold vs warm (first call vs repeat call
  * on the same instance), and the cache-data round-trip that lets webpack
  * store cached state to disk via getCachedData() / re-hydrate.
+ *
+ * Fixture lifetime policy:
+ *   - Heavy fixtures (`warmed`, `warmedConcat`, `sink`) live inside
+ *     beforeAll/afterAll hooks so they are GC'd between tasks. This keeps
+ *     the V8 heap layout independent of how many tasks the file exports —
+ *     adding a new task does not perturb pre-existing tasks' measurements.
+ *   - Light fixtures (fixtureCode, fixtureMap) stay at module scope; they
+ *     are immutable and cheap to retain.
  */
 
 import { createHash } from "crypto";
 import sources from "../../../lib/index.js";
 import { fixtureCode, fixtureMap, noop } from "../../fixtures.mjs";
 
-/**
- * Pre-sized sink used by allocation-heavy tasks to retain the constructed
- * instances past the loop so V8 cannot dead-code-eliminate them and so
- * memory pressure is predictable between samples. Overwriting existing
- * slots (rather than push/length reset) keeps the sink's hidden class
- * stable and avoids resize allocations during measurement.
- */
 const CONSTRUCT_BATCH = 100;
-const sink = Array.from({ length: CONSTRUCT_BATCH });
 
 /**
- * A CachedSource with all the common caches already populated. Reused
- * across tasks that explicitly measure the warm path.
+ * @returns {CachedSource} warmed CachedSource with all common caches populated
  */
-const warmed = (() => {
+function makeWarmed() {
 	const cached = new sources.CachedSource(
 		new sources.SourceMapSource(fixtureCode, "fixture.js", fixtureMap),
 	);
@@ -34,29 +33,43 @@ const warmed = (() => {
 	cached.buffer();
 	cached.size();
 	return cached;
-})();
+}
 
 /**
- * A CachedSource wrapping a ConcatSource of 10 RawSources with buffers()
- * already populated. Used to measure warm buffers()/buffer() delegation.
+ * @returns {CachedSource} CachedSource wrapping a ConcatSource of 10 RawSources,
+ * with buffers() already populated
  */
-const warmedConcat = (() => {
+function makeWarmedConcat() {
 	const parts = [];
 	for (let i = 0; i < 10; i++) parts.push(new sources.RawSource(fixtureCode));
 	const cached = new sources.CachedSource(new sources.ConcatSource(...parts));
 	cached.buffers();
 	return cached;
-})();
+}
 
 /**
  * @param {import("tinybench").Bench} bench bench
  */
 export default function register(bench) {
-	bench.add("cached-source: new CachedSource()", () => {
-		for (let i = 0; i < CONSTRUCT_BATCH; i++) {
-			sink[i] = new sources.CachedSource(new sources.RawSource(fixtureCode));
-		}
-	});
+	/** @type {unknown[] | undefined} */
+	let sink;
+	bench.add(
+		"cached-source: new CachedSource()",
+		() => {
+			const arr = /** @type {unknown[]} */ (sink);
+			for (let i = 0; i < CONSTRUCT_BATCH; i++) {
+				arr[i] = new sources.CachedSource(new sources.RawSource(fixtureCode));
+			}
+		},
+		{
+			beforeAll() {
+				sink = Array.from({ length: CONSTRUCT_BATCH });
+			},
+			afterAll() {
+				sink = undefined;
+			},
+		},
+	);
 
 	bench.add("cached-source: source() (cold)", () => {
 		for (let i = 0; i < 50; i++) {
@@ -64,17 +77,43 @@ export default function register(bench) {
 		}
 	});
 
-	bench.add("cached-source: source() (cached)", () => {
-		for (let i = 0; i < 500; i++) warmed.source();
-	});
+	/** @type {CachedSource | undefined} */
+	let warmed;
+	const warmedHooks = {
+		beforeAll() {
+			warmed = makeWarmed();
+		},
+		afterAll() {
+			warmed = undefined;
+		},
+	};
 
-	bench.add("cached-source: buffer() (cached)", () => {
-		for (let i = 0; i < 500; i++) warmed.buffer();
-	});
+	bench.add(
+		"cached-source: source() (cached)",
+		() => {
+			const cs = /** @type {CachedSource} */ (warmed);
+			for (let i = 0; i < 500; i++) cs.source();
+		},
+		warmedHooks,
+	);
 
-	bench.add("cached-source: buffers() (cached)", () => {
-		for (let i = 0; i < 500; i++) warmed.buffers();
-	});
+	bench.add(
+		"cached-source: buffer() (cached)",
+		() => {
+			const cs = /** @type {CachedSource} */ (warmed);
+			for (let i = 0; i < 500; i++) cs.buffer();
+		},
+		warmedHooks,
+	);
+
+	bench.add(
+		"cached-source: buffers() (cached)",
+		() => {
+			const cs = /** @type {CachedSource} */ (warmed);
+			for (let i = 0; i < 500; i++) cs.buffers();
+		},
+		warmedHooks,
+	);
 
 	bench.add("cached-source: buffer() (cold, wraps ConcatSource x10)", () => {
 		for (let i = 0; i < 10; i++) {
@@ -96,17 +135,43 @@ export default function register(bench) {
 		}
 	});
 
-	bench.add("cached-source: buffer() (warm, wraps ConcatSource x10)", () => {
-		for (let i = 0; i < 500; i++) warmedConcat.buffer();
-	});
+	/** @type {CachedSource | undefined} */
+	let warmedConcat;
+	const warmedConcatHooks = {
+		beforeAll() {
+			warmedConcat = makeWarmedConcat();
+		},
+		afterAll() {
+			warmedConcat = undefined;
+		},
+	};
 
-	bench.add("cached-source: buffers() (warm, wraps ConcatSource x10)", () => {
-		for (let i = 0; i < 500; i++) warmedConcat.buffers();
-	});
+	bench.add(
+		"cached-source: buffer() (warm, wraps ConcatSource x10)",
+		() => {
+			const cs = /** @type {CachedSource} */ (warmedConcat);
+			for (let i = 0; i < 500; i++) cs.buffer();
+		},
+		warmedConcatHooks,
+	);
 
-	bench.add("cached-source: size() (cached)", () => {
-		for (let i = 0; i < 500; i++) warmed.size();
-	});
+	bench.add(
+		"cached-source: buffers() (warm, wraps ConcatSource x10)",
+		() => {
+			const cs = /** @type {CachedSource} */ (warmedConcat);
+			for (let i = 0; i < 500; i++) cs.buffers();
+		},
+		warmedConcatHooks,
+	);
+
+	bench.add(
+		"cached-source: size() (cached)",
+		() => {
+			const cs = /** @type {CachedSource} */ (warmed);
+			for (let i = 0; i < 500; i++) cs.size();
+		},
+		warmedHooks,
+	);
 
 	bench.add("cached-source: map() (cold SourceMapSource)", () => {
 		for (let i = 0; i < 10; i++) {
@@ -116,9 +181,14 @@ export default function register(bench) {
 		}
 	});
 
-	bench.add("cached-source: map() (cached)", () => {
-		for (let i = 0; i < 500; i++) warmed.map({});
-	});
+	bench.add(
+		"cached-source: map() (cached)",
+		() => {
+			const cs = /** @type {CachedSource} */ (warmed);
+			for (let i = 0; i < 500; i++) cs.map({});
+		},
+		warmedHooks,
+	);
 
 	bench.add("cached-source: sourceAndMap() (cold)", () => {
 		for (let i = 0; i < 10; i++) {
@@ -128,9 +198,14 @@ export default function register(bench) {
 		}
 	});
 
-	bench.add("cached-source: sourceAndMap() (cached)", () => {
-		for (let i = 0; i < 500; i++) warmed.sourceAndMap({});
-	});
+	bench.add(
+		"cached-source: sourceAndMap() (cached)",
+		() => {
+			const cs = /** @type {CachedSource} */ (warmed);
+			for (let i = 0; i < 500; i++) cs.sourceAndMap({});
+		},
+		warmedHooks,
+	);
 
 	bench.add("cached-source: streamChunks() (cold)", () => {
 		for (let i = 0; i < 5; i++) {
@@ -140,11 +215,16 @@ export default function register(bench) {
 		}
 	});
 
-	bench.add("cached-source: streamChunks() (warm)", () => {
-		for (let i = 0; i < 5; i++) {
-			warmed.streamChunks({}, noop, noop, noop);
-		}
-	});
+	bench.add(
+		"cached-source: streamChunks() (warm)",
+		() => {
+			const cs = /** @type {CachedSource} */ (warmed);
+			for (let i = 0; i < 5; i++) {
+				cs.streamChunks({}, noop, noop, noop);
+			}
+		},
+		warmedHooks,
+	);
 
 	bench.add("cached-source: originalLazy()", () => {
 		const lazy = new sources.CachedSource(
@@ -168,7 +248,12 @@ export default function register(bench) {
 		}
 	});
 
-	bench.add("cached-source: updateHash() (warm)", () => {
-		for (let i = 0; i < 50; i++) warmed.updateHash(createHash("sha256"));
-	});
+	bench.add(
+		"cached-source: updateHash() (warm)",
+		() => {
+			const cs = /** @type {CachedSource} */ (warmed);
+			for (let i = 0; i < 50; i++) cs.updateHash(createHash("sha256"));
+		},
+		warmedHooks,
+	);
 }

--- a/benchmark/cases/cached-source/index.bench.mjs
+++ b/benchmark/cases/cached-source/index.bench.mjs
@@ -37,6 +37,18 @@ const warmed = (() => {
 })();
 
 /**
+ * A CachedSource wrapping a ConcatSource of 10 RawSources with buffers()
+ * already populated. Used to measure warm buffers()/buffer() delegation.
+ */
+const warmedConcat = (() => {
+	const parts = [];
+	for (let i = 0; i < 10; i++) parts.push(new sources.RawSource(fixtureCode));
+	const cached = new sources.CachedSource(new sources.ConcatSource(...parts));
+	cached.buffers();
+	return cached;
+})();
+
+/**
  * @param {import("tinybench").Bench} bench bench
  */
 export default function register(bench) {
@@ -58,6 +70,38 @@ export default function register(bench) {
 
 	bench.add("cached-source: buffer() (cached)", () => {
 		for (let i = 0; i < 500; i++) warmed.buffer();
+	});
+
+	bench.add("cached-source: buffers() (cached)", () => {
+		for (let i = 0; i < 500; i++) warmed.buffers();
+	});
+
+	bench.add("cached-source: buffer() (cold, wraps ConcatSource x10)", () => {
+		for (let i = 0; i < 10; i++) {
+			const parts = [];
+			for (let j = 0; j < 10; j++) {
+				parts.push(new sources.RawSource(fixtureCode));
+			}
+			new sources.CachedSource(new sources.ConcatSource(...parts)).buffer();
+		}
+	});
+
+	bench.add("cached-source: buffers() (cold, wraps ConcatSource x10)", () => {
+		for (let i = 0; i < 10; i++) {
+			const parts = [];
+			for (let j = 0; j < 10; j++) {
+				parts.push(new sources.RawSource(fixtureCode));
+			}
+			new sources.CachedSource(new sources.ConcatSource(...parts)).buffers();
+		}
+	});
+
+	bench.add("cached-source: buffer() (warm, wraps ConcatSource x10)", () => {
+		for (let i = 0; i < 500; i++) warmedConcat.buffer();
+	});
+
+	bench.add("cached-source: buffers() (warm, wraps ConcatSource x10)", () => {
+		for (let i = 0; i < 500; i++) warmedConcat.buffers();
 	});
 
 	bench.add("cached-source: size() (cached)", () => {

--- a/benchmark/cases/compat-source/index.bench.mjs
+++ b/benchmark/cases/compat-source/index.bench.mjs
@@ -11,10 +11,17 @@ import sources from "../../../lib/index.js";
 import { fixtureCode } from "../../fixtures.mjs";
 
 const fixtureBuffer = Buffer.from(fixtureCode, "utf8");
+const fixtureBufferArray = [fixtureBuffer];
 
 const sourceLike = {
 	source: () => fixtureCode,
 	buffer: () => fixtureBuffer,
+};
+
+const sourceLikeWithBuffers = {
+	source: () => fixtureCode,
+	buffer: () => fixtureBuffer,
+	buffers: () => fixtureBufferArray,
 };
 
 const richSourceLike = {
@@ -54,6 +61,16 @@ export default function register(bench) {
 	bench.add("compat-source: buffer() (delegated)", () => {
 		const cs = new sources.CompatSource(sourceLike);
 		for (let i = 0; i < 500; i++) cs.buffer();
+	});
+
+	bench.add("compat-source: buffers() (fallback via super)", () => {
+		const cs = new sources.CompatSource({ source: () => fixtureCode });
+		for (let i = 0; i < 50; i++) cs.buffers();
+	});
+
+	bench.add("compat-source: buffers() (delegated)", () => {
+		const cs = new sources.CompatSource(sourceLikeWithBuffers);
+		for (let i = 0; i < 500; i++) cs.buffers();
 	});
 
 	bench.add("compat-source: size() (fallback via super)", () => {

--- a/benchmark/cases/compat-source/index.bench.mjs
+++ b/benchmark/cases/compat-source/index.bench.mjs
@@ -4,99 +4,179 @@
  * CompatSource wraps a SourceLike. Interesting paths: the direct delegation
  * (when the wrapped object provides buffer/size/map/updateHash) vs the
  * Source.prototype fallback (when it doesn't).
+ *
+ * Fixture lifetime policy: SourceLike instances are built per-task in
+ * beforeAll hooks so their hidden-class state doesn't accumulate across
+ * tasks. Only the immutable fixtureCode string lives at module scope.
  */
 
 import { createHash } from "crypto";
 import sources from "../../../lib/index.js";
 import { fixtureCode } from "../../fixtures.mjs";
 
+/** @typedef {import("../../../lib/CompatSource").SourceLike} SourceLike */
+
 const fixtureBuffer = Buffer.from(fixtureCode, "utf8");
-const fixtureBufferArray = [fixtureBuffer];
-
-const sourceLike = {
-	source: () => fixtureCode,
-	buffer: () => fixtureBuffer,
-};
-
-const sourceLikeWithBuffers = {
-	source: () => fixtureCode,
-	buffer: () => fixtureBuffer,
-	buffers: () => fixtureBufferArray,
-};
-
-const richSourceLike = {
-	source: () => fixtureCode,
-	buffer: () => fixtureBuffer,
-	size: () => fixtureCode.length,
-	map: () => null,
-	sourceAndMap: () => ({ source: fixtureCode, map: null }),
-	updateHash: (hash) => {
-		hash.update(fixtureCode);
-	},
-};
 
 /**
  * @param {import("tinybench").Bench} bench bench
  */
 export default function register(bench) {
+	/** @type {SourceLike | undefined} */
+	let sourceLike;
+	const sourceLikeHooks = {
+		beforeAll() {
+			sourceLike = {
+				source: () => fixtureCode,
+				buffer: () => fixtureBuffer,
+			};
+		},
+		afterAll() {
+			sourceLike = undefined;
+		},
+	};
+
+	/** @type {SourceLike | undefined} */
+	let richSourceLike;
+	const richHooks = {
+		beforeAll() {
+			richSourceLike = {
+				source: () => fixtureCode,
+				buffer: () => fixtureBuffer,
+				size: () => fixtureCode.length,
+				map: () => null,
+				sourceAndMap: () => ({ source: fixtureCode, map: null }),
+				updateHash: (hash) => {
+					hash.update(fixtureCode);
+				},
+			};
+		},
+		afterAll() {
+			richSourceLike = undefined;
+		},
+	};
+
 	bench.add("compat-source: CompatSource.from(Source)", () => {
 		const src = new sources.RawSource(fixtureCode);
 		for (let i = 0; i < 100; i++) sources.CompatSource.from(src);
 	});
 
-	bench.add("compat-source: CompatSource.from(SourceLike)", () => {
-		for (let i = 0; i < 100; i++) sources.CompatSource.from(sourceLike);
-	});
+	bench.add(
+		"compat-source: CompatSource.from(SourceLike)",
+		() => {
+			const sl = /** @type {SourceLike} */ (sourceLike);
+			for (let i = 0; i < 100; i++) sources.CompatSource.from(sl);
+		},
+		sourceLikeHooks,
+	);
 
-	bench.add("compat-source: source() (wrapping SourceLike)", () => {
-		const cs = new sources.CompatSource(sourceLike);
-		for (let i = 0; i < 500; i++) cs.source();
-	});
+	bench.add(
+		"compat-source: source() (wrapping SourceLike)",
+		() => {
+			const cs = new sources.CompatSource(
+				/** @type {SourceLike} */ (sourceLike),
+			);
+			for (let i = 0; i < 500; i++) cs.source();
+		},
+		sourceLikeHooks,
+	);
 
 	bench.add("compat-source: buffer() (fallback via super)", () => {
 		const cs = new sources.CompatSource({ source: () => fixtureCode });
 		for (let i = 0; i < 50; i++) cs.buffer();
 	});
 
-	bench.add("compat-source: buffer() (delegated)", () => {
-		const cs = new sources.CompatSource(sourceLike);
-		for (let i = 0; i < 500; i++) cs.buffer();
-	});
+	bench.add(
+		"compat-source: buffer() (delegated)",
+		() => {
+			const cs = new sources.CompatSource(
+				/** @type {SourceLike} */ (sourceLike),
+			);
+			for (let i = 0; i < 500; i++) cs.buffer();
+		},
+		sourceLikeHooks,
+	);
 
 	bench.add("compat-source: buffers() (fallback via super)", () => {
 		const cs = new sources.CompatSource({ source: () => fixtureCode });
 		for (let i = 0; i < 50; i++) cs.buffers();
 	});
 
-	bench.add("compat-source: buffers() (delegated)", () => {
-		const cs = new sources.CompatSource(sourceLikeWithBuffers);
-		for (let i = 0; i < 500; i++) cs.buffers();
-	});
+	/** @type {SourceLike | undefined} */
+	let sourceLikeWithBuffers;
+	const sourceLikeWithBuffersHooks = {
+		beforeAll() {
+			const bufferArray = [fixtureBuffer];
+			sourceLikeWithBuffers = {
+				source: () => fixtureCode,
+				buffer: () => fixtureBuffer,
+				buffers: () => bufferArray,
+			};
+		},
+		afterAll() {
+			sourceLikeWithBuffers = undefined;
+		},
+	};
+
+	bench.add(
+		"compat-source: buffers() (delegated)",
+		() => {
+			const cs = new sources.CompatSource(
+				/** @type {SourceLike} */ (sourceLikeWithBuffers),
+			);
+			for (let i = 0; i < 500; i++) cs.buffers();
+		},
+		sourceLikeWithBuffersHooks,
+	);
 
 	bench.add("compat-source: size() (fallback via super)", () => {
 		const cs = new sources.CompatSource({ source: () => fixtureCode });
 		for (let i = 0; i < 50; i++) cs.size();
 	});
 
-	bench.add("compat-source: size() (delegated)", () => {
-		const cs = new sources.CompatSource(richSourceLike);
-		for (let i = 0; i < 500; i++) cs.size();
-	});
+	bench.add(
+		"compat-source: size() (delegated)",
+		() => {
+			const cs = new sources.CompatSource(
+				/** @type {SourceLike} */ (richSourceLike),
+			);
+			for (let i = 0; i < 500; i++) cs.size();
+		},
+		richHooks,
+	);
 
-	bench.add("compat-source: map()", () => {
-		const cs = new sources.CompatSource(richSourceLike);
-		for (let i = 0; i < 500; i++) cs.map({});
-	});
+	bench.add(
+		"compat-source: map()",
+		() => {
+			const cs = new sources.CompatSource(
+				/** @type {SourceLike} */ (richSourceLike),
+			);
+			for (let i = 0; i < 500; i++) cs.map({});
+		},
+		richHooks,
+	);
 
-	bench.add("compat-source: sourceAndMap()", () => {
-		const cs = new sources.CompatSource(richSourceLike);
-		for (let i = 0; i < 500; i++) cs.sourceAndMap({});
-	});
+	bench.add(
+		"compat-source: sourceAndMap()",
+		() => {
+			const cs = new sources.CompatSource(
+				/** @type {SourceLike} */ (richSourceLike),
+			);
+			for (let i = 0; i < 500; i++) cs.sourceAndMap({});
+		},
+		richHooks,
+	);
 
-	bench.add("compat-source: updateHash() (delegated)", () => {
-		const cs = new sources.CompatSource(richSourceLike);
-		for (let i = 0; i < 20; i++) cs.updateHash(createHash("sha256"));
-	});
+	bench.add(
+		"compat-source: updateHash() (delegated)",
+		() => {
+			const cs = new sources.CompatSource(
+				/** @type {SourceLike} */ (richSourceLike),
+			);
+			for (let i = 0; i < 20; i++) cs.updateHash(createHash("sha256"));
+		},
+		richHooks,
+	);
 
 	bench.add("compat-source: updateHash() (fallback)", () => {
 		const cs = new sources.CompatSource({ source: () => fixtureCode });

--- a/benchmark/cases/concat-source/index.bench.mjs
+++ b/benchmark/cases/concat-source/index.bench.mjs
@@ -74,6 +74,47 @@ export default function register(bench) {
 		for (let i = 0; i < 10; i++) cs.buffer();
 	});
 
+	bench.add("concat-source: buffers() (10 raw)", () => {
+		const parts = [];
+		for (let i = 0; i < 10; i++) parts.push(new sources.RawSource(fixtureCode));
+		const cs = new sources.ConcatSource(...parts);
+		for (let i = 0; i < 10; i++) cs.buffers();
+	});
+
+	bench.add("concat-source: buffer() (nested 4x10 raw)", () => {
+		const makeInner = () => {
+			const parts = [];
+			for (let i = 0; i < 10; i++) {
+				parts.push(new sources.RawSource(fixtureCode));
+			}
+			return new sources.ConcatSource(...parts);
+		};
+		const cs = new sources.ConcatSource(
+			makeInner(),
+			makeInner(),
+			makeInner(),
+			makeInner(),
+		);
+		for (let i = 0; i < 5; i++) cs.buffer();
+	});
+
+	bench.add("concat-source: buffers() (nested 4x10 raw)", () => {
+		const makeInner = () => {
+			const parts = [];
+			for (let i = 0; i < 10; i++) {
+				parts.push(new sources.RawSource(fixtureCode));
+			}
+			return new sources.ConcatSource(...parts);
+		};
+		const cs = new sources.ConcatSource(
+			makeInner(),
+			makeInner(),
+			makeInner(),
+			makeInner(),
+		);
+		for (let i = 0; i < 5; i++) cs.buffers();
+	});
+
 	bench.add("concat-source: size()", () => {
 		const cs = buildMixed();
 		for (let i = 0; i < 10; i++) cs.size();

--- a/benchmark/cases/concat-source/index.bench.mjs
+++ b/benchmark/cases/concat-source/index.bench.mjs
@@ -67,21 +67,21 @@ export default function register(bench) {
 		for (let i = 0; i < 10; i++) cs.source();
 	});
 
-	bench.add("concat-source: buffer() (10 raw)", () => {
+	/**
+	 * @returns {ConcatSource} flat ConcatSource over 10 RawSource(fixtureCode)
+	 */
+	function buildFlat10() {
 		const parts = [];
-		for (let i = 0; i < 10; i++) parts.push(new sources.RawSource(fixtureCode));
-		const cs = new sources.ConcatSource(...parts);
-		for (let i = 0; i < 10; i++) cs.buffer();
-	});
+		for (let i = 0; i < 10; i++) {
+			parts.push(new sources.RawSource(fixtureCode));
+		}
+		return new sources.ConcatSource(...parts);
+	}
 
-	bench.add("concat-source: buffers() (10 raw)", () => {
-		const parts = [];
-		for (let i = 0; i < 10; i++) parts.push(new sources.RawSource(fixtureCode));
-		const cs = new sources.ConcatSource(...parts);
-		for (let i = 0; i < 10; i++) cs.buffers();
-	});
-
-	bench.add("concat-source: buffer() (nested 4x10 raw)", () => {
+	/**
+	 * @returns {ConcatSource} nested 4x10 ConcatSource
+	 */
+	function buildNested4x10() {
 		const makeInner = () => {
 			const parts = [];
 			for (let i = 0; i < 10; i++) {
@@ -89,31 +89,71 @@ export default function register(bench) {
 			}
 			return new sources.ConcatSource(...parts);
 		};
-		const cs = new sources.ConcatSource(
+		return new sources.ConcatSource(
 			makeInner(),
 			makeInner(),
 			makeInner(),
 			makeInner(),
 		);
-		for (let i = 0; i < 5; i++) cs.buffer();
-	});
+	}
 
-	bench.add("concat-source: buffers() (nested 4x10 raw)", () => {
-		const makeInner = () => {
-			const parts = [];
-			for (let i = 0; i < 10; i++) {
-				parts.push(new sources.RawSource(fixtureCode));
-			}
-			return new sources.ConcatSource(...parts);
-		};
-		const cs = new sources.ConcatSource(
-			makeInner(),
-			makeInner(),
-			makeInner(),
-			makeInner(),
-		);
-		for (let i = 0; i < 5; i++) cs.buffers();
-	});
+	/** @type {ConcatSource | undefined} */
+	let flat10;
+	const flat10Hooks = {
+		beforeAll() {
+			flat10 = buildFlat10();
+		},
+		afterAll() {
+			flat10 = undefined;
+		},
+	};
+
+	bench.add(
+		"concat-source: buffer() (10 raw)",
+		() => {
+			const cs = /** @type {ConcatSource} */ (flat10);
+			for (let i = 0; i < 10; i++) cs.buffer();
+		},
+		flat10Hooks,
+	);
+
+	bench.add(
+		"concat-source: buffers() (10 raw)",
+		() => {
+			const cs = /** @type {ConcatSource} */ (flat10);
+			for (let i = 0; i < 10; i++) cs.buffers();
+		},
+		flat10Hooks,
+	);
+
+	/** @type {ConcatSource | undefined} */
+	let nested4x10;
+	const nested4x10Hooks = {
+		beforeAll() {
+			nested4x10 = buildNested4x10();
+		},
+		afterAll() {
+			nested4x10 = undefined;
+		},
+	};
+
+	bench.add(
+		"concat-source: buffer() (nested 4x10 raw)",
+		() => {
+			const cs = /** @type {ConcatSource} */ (nested4x10);
+			for (let i = 0; i < 5; i++) cs.buffer();
+		},
+		nested4x10Hooks,
+	);
+
+	bench.add(
+		"concat-source: buffers() (nested 4x10 raw)",
+		() => {
+			const cs = /** @type {ConcatSource} */ (nested4x10);
+			for (let i = 0; i < 5; i++) cs.buffers();
+		},
+		nested4x10Hooks,
+	);
 
 	bench.add("concat-source: size()", () => {
 		const cs = buildMixed();

--- a/benchmark/cases/realistic-source-map-pipeline/index.bench.mjs
+++ b/benchmark/cases/realistic-source-map-pipeline/index.bench.mjs
@@ -9,6 +9,10 @@
  * reuse across calls).
  *
  * This is the case that most directly reflects "compile one chunk" cost.
+ *
+ * Fixture lifetime policy: warm fixtures are built in beforeAll hooks
+ * scoped to the tasks that need them (not at module scope) so that adding
+ * a new task to this file does not perturb pre-existing measurements.
  */
 
 import sources from "../../../lib/index.js";
@@ -36,7 +40,10 @@ function buildFreshChunk() {
 	);
 }
 
-const warmChunk = (() => {
+/**
+ * @returns {CachedSource} warm CachedSource with source/map/buffer populated
+ */
+function buildWarmChunk() {
 	const cached = new sources.CachedSource(buildFreshChunk());
 	cached.source();
 	cached.map({});
@@ -44,7 +51,7 @@ const warmChunk = (() => {
 	cached.buffer();
 	cached.size();
 	return cached;
-})();
+}
 
 /*
  * Reproduces the layering pattern called out in
@@ -83,12 +90,6 @@ function buildLayeredChunk() {
 	);
 }
 
-const warmLayeredChunk = (() => {
-	const chunk = buildLayeredChunk();
-	chunk.buffers();
-	return chunk;
-})();
-
 /**
  * @param {import("tinybench").Bench} bench bench
  */
@@ -101,11 +102,24 @@ export default function register(bench) {
 		},
 	);
 
+	/** @type {CachedSource | undefined} */
+	let warmChunk;
+	const warmChunkHooks = {
+		beforeAll() {
+			warmChunk = buildWarmChunk();
+		},
+		afterAll() {
+			warmChunk = undefined;
+		},
+	};
+
 	bench.add(
 		"realistic-source-map-pipeline: warm sourceAndMap() (reuse CachedSource)",
 		() => {
-			for (let i = 0; i < 50; i++) warmChunk.sourceAndMap({});
+			const chunk = /** @type {CachedSource} */ (warmChunk);
+			for (let i = 0; i < 50; i++) chunk.sourceAndMap({});
 		},
+		warmChunkHooks,
 	);
 
 	bench.add("realistic-source-map-pipeline: cold map() only", () => {
@@ -167,17 +181,34 @@ export default function register(bench) {
 		},
 	);
 
+	/** @type {CachedSource | undefined} */
+	let warmLayeredChunk;
+	const warmLayeredHooks = {
+		beforeAll() {
+			const chunk = buildLayeredChunk();
+			chunk.buffers();
+			warmLayeredChunk = chunk;
+		},
+		afterAll() {
+			warmLayeredChunk = undefined;
+		},
+	};
+
 	bench.add(
 		"realistic-source-map-pipeline: warm buffer() (Cached->Concat->Cached->Concat)",
 		() => {
-			for (let i = 0; i < 50; i++) warmLayeredChunk.buffer();
+			const chunk = /** @type {CachedSource} */ (warmLayeredChunk);
+			for (let i = 0; i < 50; i++) chunk.buffer();
 		},
+		warmLayeredHooks,
 	);
 
 	bench.add(
 		"realistic-source-map-pipeline: warm buffers() (Cached->Concat->Cached->Concat)",
 		() => {
-			for (let i = 0; i < 50; i++) warmLayeredChunk.buffers();
+			const chunk = /** @type {CachedSource} */ (warmLayeredChunk);
+			for (let i = 0; i < 50; i++) chunk.buffers();
 		},
+		warmLayeredHooks,
 	);
 }

--- a/benchmark/cases/realistic-source-map-pipeline/index.bench.mjs
+++ b/benchmark/cases/realistic-source-map-pipeline/index.bench.mjs
@@ -46,6 +46,49 @@ const warmChunk = (() => {
 	return cached;
 })();
 
+/*
+ * Reproduces the layering pattern called out in
+ * https://github.com/webpack/webpack-sources/issues/157:
+ *
+ *   CachedSource -> ConcatSource -> CachedSource -> ConcatSource
+ *
+ * At every ConcatSource boundary, the legacy `buffer()` path calls
+ * Buffer.concat on the children's buffers, which copies all of the bytes
+ * through each layer. `buffers()` returns Buffer[] without concatenating,
+ * so the wrapping CachedSource can pass the chunks through to the consumer
+ * (e.g. fs.createWriteStream / writev) without ever materializing a single
+ * contiguous Buffer.
+ *
+ * Each inner chunk is ~5 raw sources of fixtureCode, the outer chunk stitches
+ * 4 of them together, mirroring "chunk-of-modules" nesting depth.
+ */
+/**
+ * @returns {CachedSource} cached source
+ */
+function buildLayeredChunk() {
+	const inner = [];
+	for (let i = 0; i < 4; i++) {
+		const parts = [];
+		for (let j = 0; j < 5; j++) {
+			parts.push(new sources.RawSource(fixtureCode));
+		}
+		inner.push(new sources.CachedSource(new sources.ConcatSource(...parts)));
+	}
+	return new sources.CachedSource(
+		new sources.ConcatSource(
+			new sources.RawSource("/* outer header */\n"),
+			...inner,
+			new sources.RawSource("/* outer footer */\n"),
+		),
+	);
+}
+
+const warmLayeredChunk = (() => {
+	const chunk = buildLayeredChunk();
+	chunk.buffers();
+	return chunk;
+})();
+
 /**
  * @param {import("tinybench").Bench} bench bench
  */
@@ -107,6 +150,34 @@ export default function register(bench) {
 				() => {},
 				() => {},
 			);
+		},
+	);
+
+	bench.add(
+		"realistic-source-map-pipeline: cold buffer() (Cached->Concat->Cached->Concat)",
+		() => {
+			buildLayeredChunk().buffer();
+		},
+	);
+
+	bench.add(
+		"realistic-source-map-pipeline: cold buffers() (Cached->Concat->Cached->Concat)",
+		() => {
+			buildLayeredChunk().buffers();
+		},
+	);
+
+	bench.add(
+		"realistic-source-map-pipeline: warm buffer() (Cached->Concat->Cached->Concat)",
+		() => {
+			for (let i = 0; i < 50; i++) warmLayeredChunk.buffer();
+		},
+	);
+
+	bench.add(
+		"realistic-source-map-pipeline: warm buffers() (Cached->Concat->Cached->Concat)",
+		() => {
+			for (let i = 0; i < 50; i++) warmLayeredChunk.buffers();
 		},
 	);
 }

--- a/benchmark/run.mjs
+++ b/benchmark/run.mjs
@@ -39,11 +39,16 @@ const bench = withCodSpeed(
 		now: hrtimeNow,
 		throws: true,
 		warmup: true,
-		warmupIterations: 2,
+		// Extra warmup iterations let V8's hidden-class caches and the GC heap
+		// settle before measurement starts. This matters for CodSpeed
+		// instruction counting where each task is measured in a single call,
+		// so residual allocations from previous tasks can otherwise leak into
+		// the result of subsequent tasks.
+		warmupIterations: 10,
 		// Each task's body already loops over a batch of calls, so we keep the
 		// outer iteration count low to finish a full wall-clock run in a few
-		// seconds. CodSpeed's simulation mode ignores this and instruments a
-		// single iteration per task.
+		// seconds. CodSpeed's simulation mode uses this to warm up before
+		// instrumenting a single iteration per task.
 		iterations: 10,
 	}),
 );

--- a/benchmark/with-codspeed.mjs
+++ b/benchmark/with-codspeed.mjs
@@ -30,6 +30,7 @@ import {
 /** @typedef {import("tinybench").Bench} Bench */
 /** @typedef {import("tinybench").Task} Task */
 /** @typedef {() => unknown | Promise<unknown>} Fn */
+/** @typedef {{ beforeAll?: Fn, afterAll?: Fn, beforeEach?: Fn, afterEach?: Fn }} HookOpts */
 
 const repoRoot = path.resolve(
 	path.dirname(fileURLToPath(import.meta.url)),
@@ -137,18 +138,29 @@ export function withCodSpeed(bench) {
 		setup();
 		for (const task of bench.tasks) {
 			const m = /** @type {TaskMeta} */ (meta.get(task.name));
+			const hooks = /** @type {HookOpts | undefined} */ (m.opts) || {};
+
+			if (hooks.beforeAll) await hooks.beforeAll.call(task);
 
 			// Warm-up: run the body a few times to stabilise caches / JIT.
+			// Honor beforeEach/afterEach so the measured iteration sees the
+			// same fixture state as the warmup iterations.
 			for (let i = 0; i < bench.iterations - 1; i++) {
+				if (hooks.beforeEach) await hooks.beforeEach.call(task);
 				await m.fn();
+				if (hooks.afterEach) await hooks.afterEach.call(task);
 			}
 
 			// Instrumented run.
+			if (hooks.beforeEach) await hooks.beforeEach.call(task);
 			global.gc?.();
 			InstrumentHooks.startBenchmark();
 			await wrapFrame(m.fn, true)();
 			InstrumentHooks.stopBenchmark();
+			if (hooks.afterEach) await hooks.afterEach.call(task);
 			InstrumentHooks.setExecutedBenchmark(process.pid, m.uri);
+
+			if (hooks.afterAll) await hooks.afterAll.call(task);
 
 			console.log(
 				`[CodSpeed] ${
@@ -163,14 +175,26 @@ export function withCodSpeed(bench) {
 		setup();
 		for (const task of bench.tasks) {
 			const m = /** @type {TaskMeta} */ (meta.get(task.name));
+			const hooks = /** @type {HookOpts | undefined} */ (m.opts) || {};
+
+			if (hooks.beforeAll) hooks.beforeAll.call(task);
+
 			for (let i = 0; i < bench.iterations - 1; i++) {
+				if (hooks.beforeEach) hooks.beforeEach.call(task);
 				m.fn();
+				if (hooks.afterEach) hooks.afterEach.call(task);
 			}
+
+			if (hooks.beforeEach) hooks.beforeEach.call(task);
 			global.gc?.();
 			InstrumentHooks.startBenchmark();
 			wrapFrame(m.fn, false)();
 			InstrumentHooks.stopBenchmark();
+			if (hooks.afterEach) hooks.afterEach.call(task);
 			InstrumentHooks.setExecutedBenchmark(process.pid, m.uri);
+
+			if (hooks.afterAll) hooks.afterAll.call(task);
+
 			console.log(
 				`[CodSpeed] ${
 					InstrumentHooks.isInstrumented() ? "Measured" : "Checked"

--- a/lib/CachedSource.js
+++ b/lib/CachedSource.js
@@ -116,6 +116,11 @@ class CachedSource extends Source {
 		this._cachedBuffer = cachedData ? cachedData.buffer : undefined;
 		/**
 		 * @private
+		 * @type {Buffer[] | undefined}
+		 */
+		this._cachedBuffers = undefined;
+		/**
+		 * @private
 		 * @type {number | undefined}
 		 */
 		this._cachedSize = cachedData ? cachedData.size : undefined;
@@ -228,6 +233,9 @@ class CachedSource extends Source {
 	 */
 	buffer() {
 		if (this._cachedBuffer !== undefined) return this._cachedBuffer;
+		if (this._cachedBuffers !== undefined) {
+			return (this._cachedBuffer = Buffer.concat(this._cachedBuffers));
+		}
 		if (this._cachedSource !== undefined) {
 			const value = Buffer.isBuffer(this._cachedSource)
 				? this._cachedSource
@@ -249,6 +257,21 @@ class CachedSource extends Source {
 			this._cachedBuffer = value;
 		}
 		return value;
+	}
+
+	/**
+	 * @returns {Buffer[]} buffers
+	 */
+	buffers() {
+		if (this._cachedBuffers !== undefined) return this._cachedBuffers;
+		if (this._cachedBuffer !== undefined) {
+			return (this._cachedBuffers = [this._cachedBuffer]);
+		}
+		const original = this.original();
+		if (typeof original.buffers === "function") {
+			return (this._cachedBuffers = original.buffers());
+		}
+		return (this._cachedBuffers = [this.buffer()]);
 	}
 
 	/**

--- a/lib/CompatSource.js
+++ b/lib/CompatSource.js
@@ -17,6 +17,7 @@ const Source = require("./Source");
  * @typedef {object} SourceLike
  * @property {() => SourceValue} source source
  * @property {(() => Buffer)=} buffer buffer
+ * @property {(() => Buffer[])=} buffers buffers
  * @property {(() => number)=} size size
  * @property {((options?: MapOptions) => RawSourceMap | null)=} map map
  * @property {((options?: MapOptions) => SourceAndMap)=} sourceAndMap source and map
@@ -58,6 +59,16 @@ class CompatSource extends Source {
 			return this._sourceLike.buffer();
 		}
 		return super.buffer();
+	}
+
+	/**
+	 * @returns {Buffer[]} buffers
+	 */
+	buffers() {
+		if (typeof this._sourceLike.buffers === "function") {
+			return this._sourceLike.buffers();
+		}
+		return super.buffers();
 	}
 
 	size() {

--- a/lib/ConcatSource.js
+++ b/lib/ConcatSource.js
@@ -89,11 +89,22 @@ class ConcatSource extends Source {
 	}
 
 	buffer() {
+		return Buffer.concat(this.buffers());
+	}
+
+	/**
+	 * @returns {Buffer[]} buffers
+	 */
+	buffers() {
 		if (!this._isOptimized) this._optimize();
 		/** @type {Buffer[]} */
 		const buffers = [];
 		for (const child of /** @type {SourceLike[]} */ (this._children)) {
-			if (typeof child.buffer === "function") {
+			if (typeof child.buffers === "function") {
+				for (const buffer of child.buffers()) {
+					buffers.push(buffer);
+				}
+			} else if (typeof child.buffer === "function") {
 				buffers.push(child.buffer());
 			} else {
 				const bufferOrString = child.source();
@@ -105,7 +116,7 @@ class ConcatSource extends Source {
 				}
 			}
 		}
-		return Buffer.concat(buffers);
+		return buffers;
 	}
 
 	/**

--- a/lib/SizeOnlySource.js
+++ b/lib/SizeOnlySource.js
@@ -50,6 +50,13 @@ class SizeOnlySource extends Source {
 	}
 
 	/**
+	 * @returns {Buffer[]} buffers
+	 */
+	buffers() {
+		throw this._error();
+	}
+
+	/**
 	 * @param {MapOptions=} options map options
 	 * @returns {RawSourceMap | null} map
 	 */

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -52,6 +52,13 @@ class Source {
 		return Buffer.from(source, "utf8");
 	}
 
+	/**
+	 * @returns {Buffer[]} buffers
+	 */
+	buffers() {
+		return [this.buffer()];
+	}
+
 	size() {
 		return this.buffer().length;
 	}

--- a/test/CachedSource.js
+++ b/test/CachedSource.js
@@ -4,6 +4,7 @@ jest.mock("./__mocks__/createMappingsSerializer");
 
 const crypto = require("crypto");
 const { CachedSource } = require("../");
+const { ConcatSource } = require("../");
 const { OriginalSource } = require("../");
 const { RawSource } = require("../");
 const { Source } = require("../");
@@ -546,6 +547,32 @@ describe.each([
 			() => {},
 		);
 		expect(chunks.length).toBeGreaterThan(0);
+	});
+
+	it("should return Buffer[] from buffers() and delegate to the original source", () => {
+		const original = new ConcatSource(
+			new RawSource(Buffer.from("hello ")),
+			new RawSource(Buffer.from("world")),
+		);
+		const cachedSource = new CachedSource(original);
+
+		const buffers = cachedSource.buffers();
+		expect(Array.isArray(buffers)).toBe(true);
+		expect(buffers).toHaveLength(2);
+		expect(Buffer.concat(buffers).toString("utf8")).toBe("hello world");
+		// The second call should return the cached array
+		expect(cachedSource.buffers()).toBe(buffers);
+	});
+
+	it("should return a single-entry Buffer[] from buffers() when buffer is already cached", () => {
+		const buffer = Buffer.from("cached");
+		const original = new RawSource(buffer);
+		const cachedSource = new CachedSource(original);
+		// Populate the buffer cache
+		cachedSource.buffer();
+		const buffers = cachedSource.buffers();
+		expect(buffers).toHaveLength(1);
+		expect(buffers[0]).toBe(buffer);
 	});
 
 	it("should round-trip CachedSource with a Buffer-backed source", () => {

--- a/test/CompatSource.js
+++ b/test/CompatSource.js
@@ -51,6 +51,31 @@ describe("compatSource", () => {
 		expect(source.buffer()).toBe(buffer);
 	});
 
+	it("should use buffers from source-like when provided", () => {
+		const buffers = [Buffer.from("a"), Buffer.from("b")];
+		const source = CompatSource.from({
+			source() {
+				return "ab";
+			},
+			buffers() {
+				return buffers;
+			},
+		});
+		expect(source.buffers()).toBe(buffers);
+	});
+
+	it("should fall back to super buffers() when sourceLike doesn't provide it", () => {
+		const CONTENT = "Hello";
+		const source = CompatSource.from({
+			source() {
+				return CONTENT;
+			},
+		});
+		const buffers = source.buffers();
+		expect(buffers).toHaveLength(1);
+		expect(buffers[0]).toEqual(Buffer.from(CONTENT));
+	});
+
 	it("should use size from super when sourceLike doesn't define size", () => {
 		const CONTENT = "Hello";
 		const source = CompatSource.from({

--- a/test/ConcatSource.js
+++ b/test/ConcatSource.js
@@ -229,6 +229,59 @@ describe("concatSource", () => {
 		);
 	});
 
+	it("should expose individual buffers via buffers() without concatenating", () => {
+		const a = new RawSource(Buffer.from("a"));
+		const b = new RawSource(Buffer.from("b"));
+		const c = new RawSource(Buffer.from("c"));
+		const source = new ConcatSource(a, b, c);
+		const buffers = source.buffers();
+		expect(Array.isArray(buffers)).toBe(true);
+		expect(buffers).toHaveLength(3);
+		expect(buffers[0]).toEqual(Buffer.from("a"));
+		expect(buffers[1]).toEqual(Buffer.from("b"));
+		expect(buffers[2]).toEqual(Buffer.from("c"));
+		expect(Buffer.concat(buffers)).toEqual(source.buffer());
+	});
+
+	it("should flatten nested ConcatSource buffers() into a flat Buffer[]", () => {
+		const inner = new ConcatSource(
+			new RawSource(Buffer.from("x")),
+			new RawSource(Buffer.from("y")),
+		);
+		const outer = new ConcatSource(new RawSource(Buffer.from("a")), inner);
+		const buffers = outer.buffers();
+		expect(buffers).toHaveLength(3);
+		expect(Buffer.concat(buffers).toString("utf8")).toBe("axy");
+	});
+
+	it("should fall back to buffer()/source() in buffers() for SourceLike children", () => {
+		const customBuffer = Buffer.from("custom");
+		const bufferOnly = {
+			source() {
+				return customBuffer;
+			},
+			buffer() {
+				return customBuffer;
+			},
+			size() {
+				return customBuffer.length;
+			},
+		};
+		const sourceOnly = {
+			source() {
+				return Buffer.from("more");
+			},
+			size() {
+				return 4;
+			},
+		};
+		const source = new ConcatSource(bufferOnly, sourceOnly);
+		const buffers = source.buffers();
+		expect(buffers).toHaveLength(2);
+		expect(buffers[0]).toBe(customBuffer);
+		expect(buffers[1]).toEqual(Buffer.from("more"));
+	});
+
 	it("should concat a SourceLike child where source() returns a string (no buffer())", () => {
 		const customSource = {
 			source() {

--- a/test/SizeOnlySource.js
+++ b/test/SizeOnlySource.js
@@ -8,7 +8,7 @@ describe("sizeOnlySource", () => {
 		expect(source.size()).toBe(42);
 	});
 
-	for (const method of ["source", "map", "sourceAndMap", "buffer"]) {
+	for (const method of ["source", "map", "sourceAndMap", "buffer", "buffers"]) {
 		it(`should throw on ${method}()`, () => {
 			const source = new SizeOnlySource(42);
 			expect(() => {

--- a/test/Source.js
+++ b/test/Source.js
@@ -73,4 +73,17 @@ describe("source", () => {
 		const source = new DummySource();
 		expect(source.size()).toBe(6);
 	});
+
+	it("should return a single-entry array for buffers() by default", () => {
+		class DummySource extends Source {
+			source() {
+				return "dummy";
+			}
+		}
+		const source = new DummySource();
+		const buffers = source.buffers();
+		expect(Array.isArray(buffers)).toBe(true);
+		expect(buffers).toHaveLength(1);
+		expect(buffers[0]).toEqual(Buffer.from("dummy", "utf8"));
+	});
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -318,6 +318,7 @@ declare class Source {
 	constructor();
 	source(): SourceValue;
 	buffer(): Buffer;
+	buffers(): Buffer[];
 	size(): number;
 	map(options?: MapOptions): null | RawSourceMap;
 	sourceAndMap(options?: MapOptions): SourceAndMap;
@@ -344,6 +345,11 @@ declare interface SourceLike {
 	 * buffer
 	 */
 	buffer?: () => Buffer;
+
+	/**
+	 * buffers
+	 */
+	buffers?: () => Buffer[];
 
 	/**
 	 * size


### PR DESCRIPTION
Adds a new Source.prototype.buffers() method that returns the represented
source code as an array of Buffers, avoiding the intermediate Buffer.concat
allocation that buffer() performs on composite sources such as
ConcatSource. Consumers that can accept Buffer[] (e.g. fs.createWriteStream
backed by writev) can now keep data as Buffer[] across nested
CachedSource/ConcatSource layers and write it out in one shot, which avoids
repeatedly copying the same bytes.

- Source: default buffers() returns [this.buffer()].
- ConcatSource: flattens child buffers() into a single Buffer[] without
  concatenating, and buffer() is now implemented via Buffer.concat(buffers()).
- CachedSource: caches the Buffer[] separately from the Buffer; buffer()
  concatenates lazily when requested, so repeated buffers() calls do not
  trigger copies.
- CompatSource: forwards to sourceLike.buffers() when available, otherwise
  falls back to the default.
- SizeOnlySource: throws like buffer().

Closes #157