### PR TITLE
fix: use Int32Array for signed VLQ delta accumulation in readMappings

### DIFF
--- a/.changeset/fix-signed-vlq-decoding.md
+++ b/.changeset/fix-signed-vlq-decoding.md
@@ -1,0 +1,5 @@
+---
+"webpack-sources": patch
+---
+
+fix: use Int32Array for signed VLQ delta accumulation in `readMappings` so cumulative values that go negative are preserved instead of wrapping to a large unsigned integer

--- a/lib/helpers/readMappings.js
+++ b/lib/helpers/readMappings.js
@@ -35,8 +35,8 @@ const ccMax = ccToValue.length - 1;
  * @returns {void}
  */
 const readMappings = (mappings, onMapping) => {
-	// generatedColumn, [sourceIndex, originalLine, orignalColumn, [nameIndex]]
-	const currentData = new Uint32Array([0, 0, 1, 0, 0]);
+	// generatedColumn, [sourceIndex, originalLine, originalColumn, [nameIndex]]
+	const currentData = new Int32Array([0, 0, 1, 0, 0]);
 	let currentDataPos = 0;
 	// currentValue will include a sign bit at bit 0
 	let currentValue = 0;

--- a/test/helpers-unit.js
+++ b/test/helpers-unit.js
@@ -151,6 +151,19 @@ describe("readMappings", () => {
 		});
 		expect(mappings).toHaveLength(2);
 	});
+
+	it("should preserve negative cumulative deltas (signed VLQ)", () => {
+		// Second segment "CAAD" emits deltas (+1, 0, 0, -1) which drives
+		// originalColumn negative. With an unsigned accumulator this would
+		// wrap to 4294967295.
+		const mappings = [];
+		readMappings("AAAA;CAAD", (...args) => {
+			mappings.push(args);
+		});
+		expect(mappings).toHaveLength(2);
+		expect(mappings[0]).toEqual([1, 0, 0, 1, 0, -1]);
+		expect(mappings[1]).toEqual([2, 1, 0, 1, -1, -1]);
+	});
 });
 
 describe("getFromStreamChunks", () => {


### PR DESCRIPTION
VLQ deltas are signed, so a sequence whose cumulative value goes
negative (e.g. malformed mappings) would wrap to a large unsigned
integer when stored in a Uint32Array. Switch the accumulator to
Int32Array so negative cumulative values round-trip correctly to
the onMapping callback. Also fix an "orignalColumn" typo in the
adjacent comment, and add a regression test.