### PR TITLE
fix: improve performance in many places

### DIFF
--- a/.changeset/puny-lamps-jog.md
+++ b/.changeset/puny-lamps-jog.md
@@ -1,0 +1,5 @@
+---
+"webpack-sources": patch
+---
+
+Improved performance in many places.

--- a/lib/ConcatSource.js
+++ b/lib/ConcatSource.js
@@ -222,11 +222,6 @@ class ConcatSource extends Source {
 						sourceIndex < 0 || sourceIndex >= sourceIndexMapping.length
 							? -1
 							: sourceIndexMapping[sourceIndex];
-					const resultNameIndex =
-						nameIndex < 0 || nameIndex >= nameIndexMapping.length
-							? -1
-							: nameIndexMapping[nameIndex];
-					lastMappingLine = resultSourceIndex < 0 ? 0 : generatedLine;
 					let _chunk;
 					// When using finalSource, we process the entire source code at once at the end, rather than chunk by chunk
 					if (finalSource) {
@@ -235,8 +230,17 @@ class ConcatSource extends Source {
 						_chunk = chunk;
 					}
 					if (resultSourceIndex < 0) {
+						lastMappingLine = 0;
 						onChunk(_chunk, line, column, -1, -1, -1, -1);
 					} else {
+						// Only compute the remapped name index when the chunk
+						// actually carries a source mapping; otherwise it is
+						// unused.
+						const resultNameIndex =
+							nameIndex < 0 || nameIndex >= nameIndexMapping.length
+								? -1
+								: nameIndexMapping[nameIndex];
+						lastMappingLine = generatedLine;
 						onChunk(
 							_chunk,
 							line,

--- a/lib/helpers/createMappingsSerializer.js
+++ b/lib/helpers/createMappingsSerializer.js
@@ -85,7 +85,12 @@ const createFullMappingsSerializer = () => {
 
 		let str;
 		if (currentLine < generatedLine) {
-			str = ";".repeat(generatedLine - currentLine);
+			// Consecutive lines (diff === 1) are the dominant case; avoid the
+			// `.repeat()` call entirely for them.
+			str =
+				generatedLine === currentLine + 1
+					? ";"
+					: ";".repeat(generatedLine - currentLine);
 			currentLine = generatedLine;
 			currentColumn = 0;
 			initial = false;

--- a/lib/helpers/readMappings.js
+++ b/lib/helpers/readMappings.js
@@ -71,7 +71,10 @@ const readMappings = (mappings, onMapping) => {
 						currentData[4],
 					);
 				}
-				[generatedColumn] = currentData;
+				// Direct typed-array index is faster here than destructuring,
+				// which would invoke the Int32Array iterator protocol.
+				// eslint-disable-next-line prefer-destructuring
+				generatedColumn = currentData[0];
 			}
 			currentDataPos = 0;
 			if (value === NEXT_LINE) {

--- a/lib/helpers/splitIntoPotentialTokens.js
+++ b/lib/helpers/splitIntoPotentialTokens.js
@@ -13,25 +13,6 @@
 // \r = 13
 // \t = 9
 
-// Two Uint8Array lookup tables replace the chained `===` comparisons in the
-// hot scan loops. V8 keeps the tables in L1 as a constant, so the inner
-// condition becomes a single bounds check plus a typed-array load, which is
-// cheaper than 4–6 branches per character for long inputs.
-// Indexed by charCode; entries outside the ASCII range are implicitly 0.
-const BOUNDARY = new Uint8Array(126);
-BOUNDARY[10] = 1; // \n
-BOUNDARY[59] = 1; // ;
-BOUNDARY[123] = 1; // {
-BOUNDARY[125] = 1; // }
-
-const SEPARATOR = new Uint8Array(126);
-SEPARATOR[9] = 1; // \t
-SEPARATOR[13] = 1; // \r
-SEPARATOR[32] = 1; // space
-SEPARATOR[59] = 1; // ;
-SEPARATOR[123] = 1; // {
-SEPARATOR[125] = 1; // }
-
 /**
  * @param {string} str string
  * @returns {string[] | null} array of string separated by potential tokens
@@ -45,14 +26,18 @@ const splitIntoPotentialTokens = (str) => {
 		const start = i;
 		block: {
 			let cc = str.charCodeAt(i);
-			// Advance through non-boundary characters. Non-ASCII codepoints
-			// (cc >= 126) are by definition not boundaries.
-			while (cc >= 126 || BOUNDARY[cc] === 0) {
+			while (cc !== 10 && cc !== 59 && cc !== 123 && cc !== 125) {
 				if (++i >= len) break block;
 				cc = str.charCodeAt(i);
 			}
-			// Consume trailing separators so they stay grouped with the token.
-			while (cc < 126 && SEPARATOR[cc] === 1) {
+			while (
+				cc === 59 ||
+				cc === 32 ||
+				cc === 123 ||
+				cc === 125 ||
+				cc === 13 ||
+				cc === 9
+			) {
 				if (++i >= len) break block;
 				cc = str.charCodeAt(i);
 			}

--- a/lib/helpers/splitIntoPotentialTokens.js
+++ b/lib/helpers/splitIntoPotentialTokens.js
@@ -13,6 +13,25 @@
 // \r = 13
 // \t = 9
 
+// Two Uint8Array lookup tables replace the chained `===` comparisons in the
+// hot scan loops. V8 keeps the tables in L1 as a constant, so the inner
+// condition becomes a single bounds check plus a typed-array load, which is
+// cheaper than 4–6 branches per character for long inputs.
+// Indexed by charCode; entries outside the ASCII range are implicitly 0.
+const BOUNDARY = new Uint8Array(126);
+BOUNDARY[10] = 1; // \n
+BOUNDARY[59] = 1; // ;
+BOUNDARY[123] = 1; // {
+BOUNDARY[125] = 1; // }
+
+const SEPARATOR = new Uint8Array(126);
+SEPARATOR[9] = 1; // \t
+SEPARATOR[13] = 1; // \r
+SEPARATOR[32] = 1; // space
+SEPARATOR[59] = 1; // ;
+SEPARATOR[123] = 1; // {
+SEPARATOR[125] = 1; // }
+
 /**
  * @param {string} str string
  * @returns {string[] | null} array of string separated by potential tokens
@@ -26,18 +45,14 @@ const splitIntoPotentialTokens = (str) => {
 		const start = i;
 		block: {
 			let cc = str.charCodeAt(i);
-			while (cc !== 10 && cc !== 59 && cc !== 123 && cc !== 125) {
+			// Advance through non-boundary characters. Non-ASCII codepoints
+			// (cc >= 126) are by definition not boundaries.
+			while (cc >= 126 || BOUNDARY[cc] === 0) {
 				if (++i >= len) break block;
 				cc = str.charCodeAt(i);
 			}
-			while (
-				cc === 59 ||
-				cc === 32 ||
-				cc === 123 ||
-				cc === 125 ||
-				cc === 13 ||
-				cc === 9
-			) {
+			// Consume trailing separators so they stay grouped with the token.
+			while (cc < 126 && SEPARATOR[cc] === 1) {
 				if (++i >= len) break block;
 				cc = str.charCodeAt(i);
 			}

--- a/lib/helpers/streamChunksOfCombinedSourceMap.js
+++ b/lib/helpers/streamChunksOfCombinedSourceMap.js
@@ -76,7 +76,11 @@ const streamChunksOfCombinedSourceMap = (
 		if (line > innerSourceMapLineData.length) return -1;
 		const { mappingsData } = innerSourceMapLineData[line - 1];
 		let l = 0;
-		let r = mappingsData.length / 5;
+		// `mappingsData.length` is always a multiple of 5 (five values pushed
+		// per mapping), so dividing is exact. Coerce the bound to an int32 so
+		// the binary-search loop stays on V8's fast small-int path instead of
+		// comparing an int against a float.
+		let r = (mappingsData.length / 5) | 0;
 		while (l < r) {
 			const m = (l + r) >> 1;
 			if (mappingsData[m * 5] <= column) {

--- a/lib/helpers/streamChunksOfSourceMap.js
+++ b/lib/helpers/streamChunksOfSourceMap.js
@@ -32,7 +32,8 @@ const streamChunksOfSourceMapFull = (
 	onName,
 ) => {
 	const lines = splitIntoLines(source);
-	if (lines.length === 0) {
+	const linesLength = lines.length;
+	if (linesLength === 0) {
 		return {
 			generatedLine: 1,
 			generatedColumn: 0,
@@ -52,9 +53,9 @@ const streamChunksOfSourceMapFull = (
 		}
 	}
 
-	const lastLine = lines[lines.length - 1];
+	const lastLine = lines[linesLength - 1];
 	const lastNewLine = lastLine.endsWith("\n");
-	const finalLine = lastNewLine ? lines.length + 1 : lines.length;
+	const finalLine = lastNewLine ? linesLength + 1 : linesLength;
 	const finalColumn = lastNewLine ? 0 : lastLine.length;
 
 	let currentGeneratedLine = 1;
@@ -83,7 +84,7 @@ const streamChunksOfSourceMapFull = (
 		originalColumn,
 		nameIndex,
 	) => {
-		if (mappingActive && currentGeneratedLine <= lines.length) {
+		if (mappingActive && currentGeneratedLine <= linesLength) {
 			let chunk;
 			const mappingLine = currentGeneratedLine;
 			const mappingColumn = currentGeneratedColumn;
@@ -110,7 +111,7 @@ const streamChunksOfSourceMapFull = (
 			mappingActive = false;
 		}
 		if (generatedLine > currentGeneratedLine && currentGeneratedColumn > 0) {
-			if (currentGeneratedLine <= lines.length) {
+			if (currentGeneratedLine <= linesLength) {
 				const chunk = lines[currentGeneratedLine - 1].slice(
 					currentGeneratedColumn,
 				);
@@ -127,22 +128,29 @@ const streamChunksOfSourceMapFull = (
 			currentGeneratedLine++;
 			currentGeneratedColumn = 0;
 		}
-		while (generatedLine > currentGeneratedLine) {
-			if (currentGeneratedLine <= lines.length) {
-				onChunk(
-					lines[currentGeneratedLine - 1],
-					currentGeneratedLine,
-					0,
-					-1,
-					-1,
-					-1,
-					-1,
-				);
-			}
+		// Emit each fully-passed generated line. Once we move past the last
+		// available line we stop emitting, but still need to advance the
+		// counter to `generatedLine` so subsequent state matches the caller.
+		while (
+			generatedLine > currentGeneratedLine &&
+			currentGeneratedLine <= linesLength
+		) {
+			onChunk(
+				lines[currentGeneratedLine - 1],
+				currentGeneratedLine,
+				0,
+				-1,
+				-1,
+				-1,
+				-1,
+			);
 			currentGeneratedLine++;
 		}
+		if (currentGeneratedLine < generatedLine) {
+			currentGeneratedLine = generatedLine;
+		}
 		if (generatedColumn > currentGeneratedColumn) {
-			if (currentGeneratedLine <= lines.length) {
+			if (currentGeneratedLine <= linesLength) {
 				const chunk = lines[currentGeneratedLine - 1].slice(
 					currentGeneratedColumn,
 					generatedColumn,
@@ -195,7 +203,8 @@ const streamChunksOfSourceMapLinesFull = (
 	_onName,
 ) => {
 	const lines = splitIntoLines(source);
-	if (lines.length === 0) {
+	const linesLength = lines.length;
+	if (linesLength === 0) {
 		return {
 			generatedLine: 1,
 			generatedColumn: 0,
@@ -232,39 +241,38 @@ const streamChunksOfSourceMapLinesFull = (
 		if (
 			sourceIndex < 0 ||
 			generatedLine < currentGeneratedLine ||
-			generatedLine > lines.length
+			generatedLine > linesLength
 		) {
 			return;
 		}
+		// `generatedLine <= linesLength` is guaranteed by the guard above, so
+		// every line we iterate over is in bounds — no per-iteration length
+		// check needed.
 		while (generatedLine > currentGeneratedLine) {
-			if (currentGeneratedLine <= lines.length) {
-				onChunk(
-					lines[currentGeneratedLine - 1],
-					currentGeneratedLine,
-					0,
-					-1,
-					-1,
-					-1,
-					-1,
-				);
-			}
-			currentGeneratedLine++;
-		}
-		if (generatedLine <= lines.length) {
 			onChunk(
-				lines[generatedLine - 1],
-				generatedLine,
+				lines[currentGeneratedLine - 1],
+				currentGeneratedLine,
 				0,
-				sourceIndex,
-				originalLine,
-				originalColumn,
+				-1,
+				-1,
+				-1,
 				-1,
 			);
 			currentGeneratedLine++;
 		}
+		onChunk(
+			lines[generatedLine - 1],
+			generatedLine,
+			0,
+			sourceIndex,
+			originalLine,
+			originalColumn,
+			-1,
+		);
+		currentGeneratedLine++;
 	};
 	readMappings(mappings, onMapping);
-	for (; currentGeneratedLine <= lines.length; currentGeneratedLine++) {
+	for (; currentGeneratedLine <= linesLength; currentGeneratedLine++) {
 		onChunk(
 			lines[currentGeneratedLine - 1],
 			currentGeneratedLine,
@@ -276,10 +284,10 @@ const streamChunksOfSourceMapLinesFull = (
 		);
 	}
 
-	const lastLine = lines[lines.length - 1];
+	const lastLine = lines[linesLength - 1];
 	const lastNewLine = lastLine.endsWith("\n");
 
-	const finalLine = lastNewLine ? lines.length + 1 : lines.length;
+	const finalLine = lastNewLine ? linesLength + 1 : linesLength;
 	const finalColumn = lastNewLine ? 0 : lastLine.length;
 
 	return {


### PR DESCRIPTION
- readMappings: avoid Int32Array iterator protocol by indexing
  `currentData[0]` directly instead of destructuring
- createMappingsSerializer: skip `";".repeat(1)` for the dominant
  consecutive-line case
- splitIntoPotentialTokens: replace chained `===` comparisons with
  two Uint8Array lookup tables in the hot scan loops
- streamChunksOfSourceMap: hoist `lines.length` and drop a redundant
  per-iteration bounds check; in the lines-only path the bounds check
  is already guaranteed by the leading guard
- streamChunksOfCombinedSourceMap: coerce binary-search `r` to int32
- ConcatSource.streamChunks: only compute the remapped `nameIndex`
  when the chunk actually carries a source mapping

https://claude.ai/code/session_013RELTj96iEXrmMSPxnwjeR