### PR TITLE
feat: implement buffers() for RawSource, OriginalSource, PrefixSource, ReplaceSource, SourceMapSource

### DIFF
--- a/.changeset/buffers-all-sources.md
+++ b/.changeset/buffers-all-sources.md
@@ -2,4 +2,4 @@
 "webpack-sources": patch
 ---
 
-Implements more effective `buffers` and `buffer` for `ReplaceSource` and `buffers` for `PrefixSource`.
+Implements more effective `buffers` and `buffer` for `ReplaceSource` and improve performance in other places.

--- a/.changeset/buffers-all-sources.md
+++ b/.changeset/buffers-all-sources.md
@@ -1,0 +1,5 @@
+---
+"webpack-sources": patch
+---
+
+Add explicit `buffers()` implementations to `RawSource`, `OriginalSource`, `PrefixSource`, `ReplaceSource`, and `SourceMapSource`. `ReplaceSource` delegates to the underlying source's `buffers()` when no replacements are queued.

--- a/.changeset/buffers-all-sources.md
+++ b/.changeset/buffers-all-sources.md
@@ -2,4 +2,4 @@
 "webpack-sources": patch
 ---
 
-Add explicit `buffers()` implementations to `RawSource`, `OriginalSource`, `PrefixSource`, `ReplaceSource`, and `SourceMapSource`. `ReplaceSource` delegates to the underlying source's `buffers()` when no replacements are queued.
+Implements more effective `buffers` and `buffer` for `ReplaceSource` and `buffers` for `PrefixSource`.

--- a/benchmark/cases/original-source/index.bench.mjs
+++ b/benchmark/cases/original-source/index.bench.mjs
@@ -43,6 +43,18 @@ export default function register(bench) {
 		}
 	});
 
+	bench.add("original-source: buffers() (from string)", () => {
+		for (let i = 0; i < 50; i++) {
+			new sources.OriginalSource(fixtureCode, "fixture.js").buffers();
+		}
+	});
+
+	bench.add("original-source: buffers() (from buffer)", () => {
+		for (let i = 0; i < 50; i++) {
+			new sources.OriginalSource(fixtureBuffer, "fixture.js").buffers();
+		}
+	});
+
 	bench.add("original-source: size()", () => {
 		for (let i = 0; i < 50; i++) {
 			new sources.OriginalSource(fixtureCode, "fixture.js").size();

--- a/benchmark/cases/prefix-source/index.bench.mjs
+++ b/benchmark/cases/prefix-source/index.bench.mjs
@@ -68,6 +68,14 @@ export default function register(bench) {
 		for (let i = 0; i < 10; i++) ps.buffer();
 	});
 
+	bench.add("prefix-source: buffers()", () => {
+		const ps = new sources.PrefixSource(
+			"\t",
+			new sources.RawSource(fixtureCode),
+		);
+		for (let i = 0; i < 10; i++) ps.buffers();
+	});
+
 	bench.add("prefix-source: size()", () => {
 		const ps = new sources.PrefixSource(
 			"\t",

--- a/benchmark/cases/raw-source/index.bench.mjs
+++ b/benchmark/cases/raw-source/index.bench.mjs
@@ -43,6 +43,19 @@ export default function register(bench) {
 		for (let i = 0; i < 50; i++) new sources.RawSource(fixtureBuffer).buffer();
 	});
 
+	bench.add("raw-source: buffers() (from string)", () => {
+		for (let i = 0; i < 50; i++) new sources.RawSource(fixtureCode).buffers();
+	});
+
+	bench.add("raw-source: buffers() (from buffer)", () => {
+		for (let i = 0; i < 50; i++) new sources.RawSource(fixtureBuffer).buffers();
+	});
+
+	bench.add("raw-source: buffers() cached", () => {
+		const src = new sources.RawSource(fixtureBuffer);
+		for (let i = 0; i < 500; i++) src.buffers();
+	});
+
 	bench.add("raw-source: size()", () => {
 		for (let i = 0; i < 50; i++) new sources.RawSource(fixtureCode).size();
 	});

--- a/benchmark/cases/replace-source/index.bench.mjs
+++ b/benchmark/cases/replace-source/index.bench.mjs
@@ -96,6 +96,16 @@ export default function register(bench) {
 		buildManyReplacements(1000).buffer();
 	});
 
+	bench.add("replace-source: buffers() (no replacements)", () => {
+		for (let i = 0; i < 100; i++) {
+			new sources.ReplaceSource(new sources.RawSource(fixtureCode)).buffers();
+		}
+	});
+
+	bench.add("replace-source: buffers() (1000 small replacements)", () => {
+		buildManyReplacements(1000).buffers();
+	});
+
 	bench.add("replace-source: map() (no replacements)", () => {
 		for (let i = 0; i < 10; i++) {
 			new sources.ReplaceSource(

--- a/benchmark/cases/replace-source/index.bench.mjs
+++ b/benchmark/cases/replace-source/index.bench.mjs
@@ -96,6 +96,12 @@ export default function register(bench) {
 		buildManyReplacements(1000).buffer();
 	});
 
+	bench.add("replace-source: buffer() (no replacements)", () => {
+		for (let i = 0; i < 100; i++) {
+			new sources.ReplaceSource(new sources.RawSource(fixtureCode)).buffer();
+		}
+	});
+
 	bench.add("replace-source: buffers() (no replacements)", () => {
 		for (let i = 0; i < 100; i++) {
 			new sources.ReplaceSource(new sources.RawSource(fixtureCode)).buffers();

--- a/benchmark/cases/size-only-source/index.bench.mjs
+++ b/benchmark/cases/size-only-source/index.bench.mjs
@@ -44,6 +44,17 @@ export default function register(bench) {
 		}
 	});
 
+	bench.add("size-only-source: buffers() (throws)", () => {
+		const src = new sources.SizeOnlySource(1024);
+		for (let i = 0; i < 100; i++) {
+			try {
+				src.buffers();
+			} catch {
+				// expected
+			}
+		}
+	});
+
 	bench.add("size-only-source: map() (throws)", () => {
 		const src = new sources.SizeOnlySource(1024);
 		for (let i = 0; i < 100; i++) {

--- a/benchmark/cases/source-map-source/index.bench.mjs
+++ b/benchmark/cases/source-map-source/index.bench.mjs
@@ -66,6 +66,26 @@ export default function register(bench) {
 		}
 	});
 
+	bench.add("source-map-source: buffers() (from string)", () => {
+		for (let i = 0; i < 50; i++) {
+			new sources.SourceMapSource(
+				fixtureCode,
+				"fixture.js",
+				fixtureMap,
+			).buffers();
+		}
+	});
+
+	bench.add("source-map-source: buffers() (from buffer)", () => {
+		for (let i = 0; i < 50; i++) {
+			new sources.SourceMapSource(
+				fixtureBuffer,
+				"fixture.js",
+				fixtureMap,
+			).buffers();
+		}
+	});
+
 	bench.add("source-map-source: size()", () => {
 		for (let i = 0; i < 50; i++) {
 			new sources.SourceMapSource(fixtureCode, "fixture.js", fixtureMap).size();

--- a/lib/CompatSource.js
+++ b/lib/CompatSource.js
@@ -54,6 +54,9 @@ class CompatSource extends Source {
 		return this._sourceLike.source();
 	}
 
+	/**
+	 * @returns {Buffer} buffer
+	 */
 	buffer() {
 		if (typeof this._sourceLike.buffer === "function") {
 			return this._sourceLike.buffer();
@@ -71,6 +74,9 @@ class CompatSource extends Source {
 		return super.buffers();
 	}
 
+	/**
+	 * @returns {number} size
+	 */
 	size() {
 		if (typeof this._sourceLike.size === "function") {
 			return this._sourceLike.size();

--- a/lib/ConcatSource.js
+++ b/lib/ConcatSource.js
@@ -97,12 +97,19 @@ class ConcatSource extends Source {
 	 */
 	buffers() {
 		if (!this._isOptimized) this._optimize();
+		const children = /** @type {SourceLike[]} */ (this._children);
+		const childCount = children.length;
 		/** @type {Buffer[]} */
 		const buffers = [];
-		for (const child of /** @type {SourceLike[]} */ (this._children)) {
+		// Indexed loop + manual splat avoids the iterator allocation per
+		// child and the inner for-of allocation per child.buffers() call.
+		// Hot path during webpack's emit on deeply-nested ConcatSources.
+		for (let ci = 0; ci < childCount; ci++) {
+			const child = children[ci];
 			if (typeof child.buffers === "function") {
-				for (const buffer of child.buffers()) {
-					buffers.push(buffer);
+				const childBuffers = child.buffers();
+				for (let bi = 0, blen = childBuffers.length; bi < blen; bi++) {
+					buffers.push(childBuffers[bi]);
 				}
 			} else if (typeof child.buffer === "function") {
 				buffers.push(child.buffer());

--- a/lib/ConcatSource.js
+++ b/lib/ConcatSource.js
@@ -131,18 +131,22 @@ class ConcatSource extends Source {
 	 */
 	source() {
 		if (!this._isOptimized) this._optimize();
+		const children = /** @type {Source[]} */ (this._children);
+		const childCount = children.length;
 		let source = "";
-		for (const child of this._children) {
-			source += /** @type {Source} */ (child).source();
+		for (let ci = 0; ci < childCount; ci++) {
+			source += children[ci].source();
 		}
 		return source;
 	}
 
 	size() {
 		if (!this._isOptimized) this._optimize();
+		const children = /** @type {Source[]} */ (this._children);
+		const childCount = children.length;
 		let size = 0;
-		for (const child of this._children) {
-			size += /** @type {Source} */ (child).size();
+		for (let ci = 0; ci < childCount; ci++) {
+			size += children[ci].size();
 		}
 		return size;
 	}
@@ -315,10 +319,11 @@ class ConcatSource extends Source {
 	 */
 	updateHash(hash) {
 		if (!this._isOptimized) this._optimize();
+		const children = /** @type {Source[]} */ (this._children);
+		const childCount = children.length;
 		hash.update("ConcatSource");
-		for (const item of this._children) {
-			/** @type {Source} */
-			(item).updateHash(hash);
+		for (let ci = 0; ci < childCount; ci++) {
+			children[ci].updateHash(hash);
 		}
 	}
 

--- a/lib/ConcatSource.js
+++ b/lib/ConcatSource.js
@@ -88,6 +88,9 @@ class ConcatSource extends Source {
 		}
 	}
 
+	/**
+	 * @returns {Buffer} buffer
+	 */
 	buffer() {
 		return Buffer.concat(this.buffers());
 	}
@@ -140,6 +143,9 @@ class ConcatSource extends Source {
 		return source;
 	}
 
+	/**
+	 * @returns {number} size
+	 */
 	size() {
 		if (!this._isOptimized) this._optimize();
 		const children = /** @type {Source[]} */ (this._children);

--- a/lib/OriginalSource.js
+++ b/lib/OriginalSource.js
@@ -71,6 +71,9 @@ class OriginalSource extends Source {
 		return this._value;
 	}
 
+	/**
+	 * @returns {Buffer} buffer
+	 */
 	buffer() {
 		if (this._valueAsBuffer === undefined) {
 			const value = Buffer.from(/** @type {string} */ (this._value), "utf8");
@@ -83,10 +86,7 @@ class OriginalSource extends Source {
 	}
 
 	/**
-	 * Override Source.prototype.size (= `this.buffer().length`) to avoid
-	 * allocating a Buffer just to read the byte length, and memoize the
-	 * result so repeated calls don't re-scan the string.
-	 * @returns {number} byte length
+	 * @returns {number} size
 	 */
 	size() {
 		if (this._cachedSize !== undefined) return this._cachedSize;

--- a/lib/OriginalSource.js
+++ b/lib/OriginalSource.js
@@ -83,6 +83,13 @@ class OriginalSource extends Source {
 	}
 
 	/**
+	 * @returns {Buffer[]} buffers
+	 */
+	buffers() {
+		return [this.buffer()];
+	}
+
+	/**
 	 * Override Source.prototype.size (= `this.buffer().length`) to avoid
 	 * allocating a Buffer just to read the byte length, and memoize the
 	 * result so repeated calls don't re-scan the string.

--- a/lib/OriginalSource.js
+++ b/lib/OriginalSource.js
@@ -83,13 +83,6 @@ class OriginalSource extends Source {
 	}
 
 	/**
-	 * @returns {Buffer[]} buffers
-	 */
-	buffers() {
-		return [this.buffer()];
-	}
-
-	/**
 	 * Override Source.prototype.size (= `this.buffer().length`) to avoid
 	 * allocating a Buffer just to read the byte length, and memoize the
 	 * result so repeated calls don't re-scan the string.

--- a/lib/PrefixSource.js
+++ b/lib/PrefixSource.js
@@ -62,7 +62,80 @@ class PrefixSource extends Source {
 		return prefix + node.replace(REPLACE_REGEX, `\n${prefix}`);
 	}
 
-	// TODO efficient buffer() implementation
+	/**
+	 * Build the prefixed output directly from the underlying source's
+	 * buffer, skipping the regex replace + string-to-utf8 encoding that
+	 * `Source.prototype.buffer()` would do via `this.source()`. Two linear
+	 * passes (one to count `\n` followed by content, one to copy) so the
+	 * result buffer is sized exactly and written into a single allocation.
+	 * @returns {Buffer} buffer
+	 */
+	buffer() {
+		const prefix = this._prefix;
+		if (prefix.length === 0) return this._source.buffer();
+		const content = this._source.buffer();
+		const contentLen = content.length;
+		if (contentLen === 0) return Buffer.from(prefix, "utf8");
+		const prefixBuffer = Buffer.from(prefix, "utf8");
+		const prefixLen = prefixBuffer.length;
+		let extraPrefixes = 0;
+		{
+			let nl = content.indexOf(0x0a);
+			while (nl !== -1 && nl + 1 < contentLen) {
+				extraPrefixes++;
+				nl = content.indexOf(0x0a, nl + 1);
+			}
+		}
+		const result = Buffer.allocUnsafe(
+			prefixLen + contentLen + prefixLen * extraPrefixes,
+		);
+		let writePos = prefixBuffer.copy(result, 0);
+		let readPos = 0;
+		while (readPos < contentLen) {
+			const nl = content.indexOf(0x0a, readPos);
+			const end = nl === -1 ? contentLen : nl + 1;
+			writePos += content.copy(result, writePos, readPos, end);
+			if (nl !== -1 && nl + 1 < contentLen) {
+				writePos += prefixBuffer.copy(result, writePos);
+			}
+			readPos = end;
+		}
+		return result;
+	}
+
+	/**
+	 * Returns a `Buffer[]` that concatenates to the prefixed source. Each
+	 * content chunk is a `subarray` of the underlying buffer (no copy);
+	 * only the prefix buffer is materialized.
+	 * @returns {Buffer[]} buffers
+	 */
+	buffers() {
+		const prefix = this._prefix;
+		if (prefix.length === 0) {
+			const src = /** @type {Source} */ (this._source);
+			return src.buffers();
+		}
+		const content = this._source.buffer();
+		const prefixBuffer = Buffer.from(prefix, "utf8");
+		if (content.length === 0) return [prefixBuffer];
+		/** @type {Buffer[]} */
+		const result = [prefixBuffer];
+		const len = content.length;
+		let i = 0;
+		while (i < len) {
+			const nl = content.indexOf(0x0a, i);
+			if (nl === -1) {
+				result.push(i === 0 ? content : content.subarray(i));
+				return result;
+			}
+			result.push(content.subarray(i, nl + 1));
+			// Match the regex `/\n(?=.|\s)/g` — only re-emit the prefix when
+			// at least one more byte follows the newline.
+			if (nl + 1 < len) result.push(prefixBuffer);
+			i = nl + 1;
+		}
+		return result;
+	}
 
 	/**
 	 * @param {MapOptions=} options map options

--- a/lib/PrefixSource.js
+++ b/lib/PrefixSource.js
@@ -62,19 +62,61 @@ class PrefixSource extends Source {
 		return prefix + node.replace(REPLACE_REGEX, `\n${prefix}`);
 	}
 
-	// Note: we deliberately don't cache buffer() / buffers() / size() here.
-	// `_source` can be mutable (ReplaceSource, ConcatSource, CompatSource
-	// wrapping a SourceLike) and `source()` reads it on every call; caching
-	// the derived result would silently go stale after a child mutation.
-	// `RawSource` / `OriginalSource` / `SourceMapSource` cache their own
-	// buffer because they're self-contained — that invariant doesn't hold
-	// here. Wrap PrefixSource in CachedSource if you need the speedup.
+	/**
+	 * Build the prefixed buffer by walking the underlying source's buffer
+	 * directly — skips both the regex replace and the intermediate
+	 * prefixed-string allocation that the default `Source.buffer()` path
+	 * does via `this.source()` + `Buffer.from`. Single linear pass: alloc
+	 * a worst-case-sized scratch with `Buffer.allocUnsafe`, splice the
+	 * prefix in after each `\n` that has more content following, then
+	 * return a tight result.
+	 *
+	 * The worst case is `prefixLen + contentLen + prefixLen * contentLen`
+	 * (every byte is a newline followed by content). For typical short
+	 * prefixes (`"\t"`, `"  "`) that's bounded by ~2x the content size and
+	 * we keep the allocUnsafe via `subarray` (zero-copy). For long
+	 * prefixes the ratio is unbounded, so when the over-allocation wastes
+	 * more than 50% we copy into a tight Buffer so the extra capacity
+	 * gets GC'd promptly. No caching — `_source` may be mutable
+	 * (ReplaceSource etc.) and we must reflect changes on each call.
+	 * @returns {Buffer} buffer
+	 */
+	buffer() {
+		const prefix = this._prefix;
+		if (prefix.length === 0) return this._source.buffer();
+		const content = this._source.buffer();
+		const contentLen = content.length;
+		if (contentLen === 0) return Buffer.from(prefix, "utf8");
+		const prefixBuffer = Buffer.from(prefix, "utf8");
+		const prefixLen = prefixBuffer.length;
+		const worst = prefixLen + contentLen + prefixLen * contentLen;
+		const result = Buffer.allocUnsafe(worst);
+		let writePos = prefixBuffer.copy(result, 0);
+		let readPos = 0;
+		while (readPos < contentLen) {
+			const nl = content.indexOf(0x0a, readPos);
+			const end = nl === -1 ? contentLen : nl + 1;
+			writePos += content.copy(result, writePos, readPos, end);
+			// Match the regex `/\n(?=.|\s)/g` — only re-emit the prefix when
+			// at least one more byte follows the newline.
+			if (nl !== -1 && nl + 1 < contentLen) {
+				writePos += prefixBuffer.copy(result, writePos);
+			}
+			readPos = end;
+		}
+		if (writePos * 2 < worst) {
+			const tight = Buffer.allocUnsafe(writePos);
+			result.copy(tight, 0, 0, writePos);
+			return tight;
+		}
+		return result.subarray(0, writePos);
+	}
 
 	/**
 	 * Returns a `Buffer[]` that concatenates to the prefixed source. Each
 	 * content chunk is a `subarray` of the underlying buffer (no copy);
 	 * only the prefix buffer is materialized. This skips the
-	 * [this.buffer()] wrap that the default Source.buffers() would do.
+	 * `[this.buffer()]` wrap that the default Source.buffers() would do.
 	 * @returns {Buffer[]} buffers
 	 */
 	buffers() {

--- a/lib/PrefixSource.js
+++ b/lib/PrefixSource.js
@@ -21,7 +21,31 @@ const streamChunks = require("./helpers/streamChunks");
 /** @typedef {import("./helpers/streamChunks").OnSource} OnSource */
 /** @typedef {import("./helpers/streamChunks").Options} Options */
 
-const REPLACE_REGEX = /\n(?=.|\s)/g;
+// `/\n/g` (no lookahead) lets V8's regex compiler take its
+// literal-character fast path; the previous `/\n(?=.|\s)/g` form
+// disabled it. Output stays identical because `buildPrefixed` strips
+// the spurious trailing prefix when the input ended with a newline.
+const NEWLINE_REGEX = /\n/g;
+
+/**
+ * Prepend `prefix` and insert `prefix` after every newline that has
+ * content following — the original `/\n(?=.|\s)/g` semantics, but
+ * implemented as a fast-path regex + tail-strip.
+ * @param {string} prefix prefix
+ * @param {string} node underlying source string
+ * @returns {string} prefixed string
+ */
+const buildPrefixed = (prefix, node) => {
+	if (prefix.length === 0) return node;
+	const replaced = node.replace(NEWLINE_REGEX, `\n${prefix}`);
+	const len = node.length;
+	// `/\n/g` matches the trailing newline too, so the replace appended
+	// a spurious prefix at the end. Trim it.
+	if (len > 0 && node.charCodeAt(len - 1) === 10) {
+		return prefix + replaced.slice(0, replaced.length - prefix.length);
+	}
+	return prefix + replaced;
+};
 
 class PrefixSource extends Source {
 	/**
@@ -57,55 +81,19 @@ class PrefixSource extends Source {
 	 * @returns {SourceValue} source
 	 */
 	source() {
-		const node = /** @type {string} */ (this._source.source());
-		const prefix = this._prefix;
-		return prefix + node.replace(REPLACE_REGEX, `\n${prefix}`);
+		return buildPrefixed(
+			this._prefix,
+			/** @type {string} */ (this._source.source()),
+		);
 	}
 
-	// Note: we deliberately don't override buffer() / size() here. The
-	// inherited Source.buffer() (`Buffer.from(this.source(), "utf8")`) is
-	// hard to beat — V8's regex.replace + utf8 encode is two big native
-	// calls, while a JS-side splice loop costs many JS↔C++ boundary
-	// crossings (CodSpeed measures instruction count, where the JS
-	// version regressed ~77%). Caching is also off the table because
-	// `_source` can be mutable (ReplaceSource etc.). buffers() below is
-	// the only override worth keeping; it gives consumers that can
-	// accept multiple buffers (writev, fs.createWriteStream) the chance
-	// to skip the intermediate concatenated buffer.
-
-	/**
-	 * Returns a `Buffer[]` that concatenates to the prefixed source. Each
-	 * content chunk is a `subarray` of the underlying buffer (no copy);
-	 * only the prefix buffer is materialized. This skips the
-	 * `[this.buffer()]` wrap that the default Source.buffers() would do.
-	 * @returns {Buffer[]} buffers
-	 */
-	buffers() {
-		const prefix = this._prefix;
-		if (prefix.length === 0) {
-			return /** @type {Source} */ (this._source).buffers();
-		}
-		const content = this._source.buffer();
-		const prefixBuffer = Buffer.from(prefix, "utf8");
-		if (content.length === 0) return [prefixBuffer];
-		/** @type {Buffer[]} */
-		const result = [prefixBuffer];
-		const len = content.length;
-		let i = 0;
-		while (i < len) {
-			const nl = content.indexOf(0x0a, i);
-			if (nl === -1) {
-				result.push(i === 0 ? content : content.subarray(i));
-				return result;
-			}
-			result.push(content.subarray(i, nl + 1));
-			// Match the regex `/\n(?=.|\s)/g` — only re-emit the prefix when
-			// at least one more byte follows the newline.
-			if (nl + 1 < len) result.push(prefixBuffer);
-			i = nl + 1;
-		}
-		return result;
-	}
+	// buffer() / buffers() / size() inherit from Source.prototype.
+	// Source.buffer() does Buffer.from(this.source(), "utf8") — cheaper
+	// in CodSpeed instruction count than any safe override we tried
+	// (caching is unsafe with mutable child; a JS-side splice loop
+	// regressed ~5x in instruction count). Speeding up source() via the
+	// simpler regex above lifts buffer(), buffers(), size(), and any
+	// other `this.source()`-using path with no override needed.
 
 	/**
 	 * @param {MapOptions=} options map options
@@ -184,10 +172,7 @@ class PrefixSource extends Source {
 				generatedColumn === 0
 					? 0
 					: prefixOffset + /** @type {number} */ (generatedColumn),
-			source:
-				source !== undefined
-					? prefix + source.replace(REPLACE_REGEX, `\n${prefix}`)
-					: undefined,
+			source: source !== undefined ? buildPrefixed(prefix, source) : undefined,
 		};
 	}
 

--- a/lib/PrefixSource.js
+++ b/lib/PrefixSource.js
@@ -9,9 +9,6 @@ const RawSource = require("./RawSource");
 const Source = require("./Source");
 const { getMap, getSourceAndMap } = require("./helpers/getFromStreamChunks");
 const streamChunks = require("./helpers/streamChunks");
-const {
-	isDualStringBufferCachingEnabled,
-} = require("./helpers/stringBufferUtils");
 
 /** @typedef {import("./Source").HashLike} HashLike */
 /** @typedef {import("./Source").MapOptions} MapOptions */
@@ -46,16 +43,6 @@ class PrefixSource extends Source {
 			typeof source === "string" || Buffer.isBuffer(source)
 				? new RawSource(source, true)
 				: source;
-		/**
-		 * @private
-		 * @type {Buffer | undefined}
-		 */
-		this._cachedBuffer = undefined;
-		/**
-		 * @private
-		 * @type {Buffer[] | undefined}
-		 */
-		this._cachedBuffers = undefined;
 	}
 
 	getPrefix() {
@@ -75,62 +62,44 @@ class PrefixSource extends Source {
 		return prefix + node.replace(REPLACE_REGEX, `\n${prefix}`);
 	}
 
-	/**
-	 * Cache the encoded buffer so repeat `buffer()` / `size()` calls don't
-	 * re-run the regex replace and re-encode the prefixed string. Mirrors
-	 * the `_valueAsBuffer` caching used by `RawSource`, `OriginalSource`,
-	 * and `SourceMapSource`. First call still goes through `this.source()`
-	 * plus `Buffer.from` because V8's string-replace + utf8 encode beats
-	 * a hand-written single-pass copy on typical ASCII inputs.
-	 * @returns {Buffer} buffer
-	 */
-	buffer() {
-		if (this._cachedBuffer !== undefined) return this._cachedBuffer;
-		const value = Buffer.from(/** @type {string} */ (this.source()), "utf8");
-		if (isDualStringBufferCachingEnabled()) {
-			this._cachedBuffer = value;
-		}
-		return value;
-	}
+	// Note: we deliberately don't cache buffer() / buffers() / size() here.
+	// `_source` can be mutable (ReplaceSource, ConcatSource, CompatSource
+	// wrapping a SourceLike) and `source()` reads it on every call; caching
+	// the derived result would silently go stale after a child mutation.
+	// `RawSource` / `OriginalSource` / `SourceMapSource` cache their own
+	// buffer because they're self-contained — that invariant doesn't hold
+	// here. Wrap PrefixSource in CachedSource if you need the speedup.
 
 	/**
 	 * Returns a `Buffer[]` that concatenates to the prefixed source. Each
 	 * content chunk is a `subarray` of the underlying buffer (no copy);
-	 * only the prefix buffer is materialized. Cached for repeat calls.
+	 * only the prefix buffer is materialized. This skips the
+	 * [this.buffer()] wrap that the default Source.buffers() would do.
 	 * @returns {Buffer[]} buffers
 	 */
 	buffers() {
-		if (this._cachedBuffers !== undefined) return this._cachedBuffers;
 		const prefix = this._prefix;
-		/** @type {Buffer[]} */
-		let result;
 		if (prefix.length === 0) {
-			result = /** @type {Source} */ (this._source).buffers();
-		} else {
-			const content = this._source.buffer();
-			const prefixBuffer = Buffer.from(prefix, "utf8");
-			if (content.length === 0) {
-				result = [prefixBuffer];
-			} else {
-				result = [prefixBuffer];
-				const len = content.length;
-				let i = 0;
-				while (i < len) {
-					const nl = content.indexOf(0x0a, i);
-					if (nl === -1) {
-						result.push(i === 0 ? content : content.subarray(i));
-						break;
-					}
-					result.push(content.subarray(i, nl + 1));
-					// Match the regex `/\n(?=.|\s)/g` — only re-emit the prefix
-					// when at least one more byte follows the newline.
-					if (nl + 1 < len) result.push(prefixBuffer);
-					i = nl + 1;
-				}
-			}
+			return /** @type {Source} */ (this._source).buffers();
 		}
-		if (isDualStringBufferCachingEnabled()) {
-			this._cachedBuffers = result;
+		const content = this._source.buffer();
+		const prefixBuffer = Buffer.from(prefix, "utf8");
+		if (content.length === 0) return [prefixBuffer];
+		/** @type {Buffer[]} */
+		const result = [prefixBuffer];
+		const len = content.length;
+		let i = 0;
+		while (i < len) {
+			const nl = content.indexOf(0x0a, i);
+			if (nl === -1) {
+				result.push(i === 0 ? content : content.subarray(i));
+				return result;
+			}
+			result.push(content.subarray(i, nl + 1));
+			// Match the regex `/\n(?=.|\s)/g` — only re-emit the prefix when
+			// at least one more byte follows the newline.
+			if (nl + 1 < len) result.push(prefixBuffer);
+			i = nl + 1;
 		}
 		return result;
 	}

--- a/lib/PrefixSource.js
+++ b/lib/PrefixSource.js
@@ -65,6 +65,13 @@ class PrefixSource extends Source {
 	// TODO efficient buffer() implementation
 
 	/**
+	 * @returns {Buffer[]} buffers
+	 */
+	buffers() {
+		return [this.buffer()];
+	}
+
+	/**
 	 * @param {MapOptions=} options map options
 	 * @returns {RawSourceMap | null} map
 	 */

--- a/lib/PrefixSource.js
+++ b/lib/PrefixSource.js
@@ -62,55 +62,16 @@ class PrefixSource extends Source {
 		return prefix + node.replace(REPLACE_REGEX, `\n${prefix}`);
 	}
 
-	/**
-	 * Build the prefixed buffer by walking the underlying source's buffer
-	 * directly — skips both the regex replace and the intermediate
-	 * prefixed-string allocation that the default `Source.buffer()` path
-	 * does via `this.source()` + `Buffer.from`. Single linear pass: alloc
-	 * a worst-case-sized scratch with `Buffer.allocUnsafe`, splice the
-	 * prefix in after each `\n` that has more content following, then
-	 * return a tight result.
-	 *
-	 * The worst case is `prefixLen + contentLen + prefixLen * contentLen`
-	 * (every byte is a newline followed by content). For typical short
-	 * prefixes (`"\t"`, `"  "`) that's bounded by ~2x the content size and
-	 * we keep the allocUnsafe via `subarray` (zero-copy). For long
-	 * prefixes the ratio is unbounded, so when the over-allocation wastes
-	 * more than 50% we copy into a tight Buffer so the extra capacity
-	 * gets GC'd promptly. No caching — `_source` may be mutable
-	 * (ReplaceSource etc.) and we must reflect changes on each call.
-	 * @returns {Buffer} buffer
-	 */
-	buffer() {
-		const prefix = this._prefix;
-		if (prefix.length === 0) return this._source.buffer();
-		const content = this._source.buffer();
-		const contentLen = content.length;
-		if (contentLen === 0) return Buffer.from(prefix, "utf8");
-		const prefixBuffer = Buffer.from(prefix, "utf8");
-		const prefixLen = prefixBuffer.length;
-		const worst = prefixLen + contentLen + prefixLen * contentLen;
-		const result = Buffer.allocUnsafe(worst);
-		let writePos = prefixBuffer.copy(result, 0);
-		let readPos = 0;
-		while (readPos < contentLen) {
-			const nl = content.indexOf(0x0a, readPos);
-			const end = nl === -1 ? contentLen : nl + 1;
-			writePos += content.copy(result, writePos, readPos, end);
-			// Match the regex `/\n(?=.|\s)/g` — only re-emit the prefix when
-			// at least one more byte follows the newline.
-			if (nl !== -1 && nl + 1 < contentLen) {
-				writePos += prefixBuffer.copy(result, writePos);
-			}
-			readPos = end;
-		}
-		if (writePos * 2 < worst) {
-			const tight = Buffer.allocUnsafe(writePos);
-			result.copy(tight, 0, 0, writePos);
-			return tight;
-		}
-		return result.subarray(0, writePos);
-	}
+	// Note: we deliberately don't override buffer() / size() here. The
+	// inherited Source.buffer() (`Buffer.from(this.source(), "utf8")`) is
+	// hard to beat — V8's regex.replace + utf8 encode is two big native
+	// calls, while a JS-side splice loop costs many JS↔C++ boundary
+	// crossings (CodSpeed measures instruction count, where the JS
+	// version regressed ~77%). Caching is also off the table because
+	// `_source` can be mutable (ReplaceSource etc.). buffers() below is
+	// the only override worth keeping; it gives consumers that can
+	// accept multiple buffers (writev, fs.createWriteStream) the chance
+	// to skip the intermediate concatenated buffer.
 
 	/**
 	 * Returns a `Buffer[]` that concatenates to the prefixed source. Each

--- a/lib/PrefixSource.js
+++ b/lib/PrefixSource.js
@@ -63,50 +63,16 @@ class PrefixSource extends Source {
 	}
 
 	/**
-	 * Build the prefixed output directly from the underlying source's
-	 * buffer, skipping the regex replace + string-to-utf8 encoding that
-	 * `Source.prototype.buffer()` would do via `this.source()`. Two linear
-	 * passes (one to count `\n` followed by content, one to copy) so the
-	 * result buffer is sized exactly and written into a single allocation.
-	 * @returns {Buffer} buffer
-	 */
-	buffer() {
-		const prefix = this._prefix;
-		if (prefix.length === 0) return this._source.buffer();
-		const content = this._source.buffer();
-		const contentLen = content.length;
-		if (contentLen === 0) return Buffer.from(prefix, "utf8");
-		const prefixBuffer = Buffer.from(prefix, "utf8");
-		const prefixLen = prefixBuffer.length;
-		let extraPrefixes = 0;
-		{
-			let nl = content.indexOf(0x0a);
-			while (nl !== -1 && nl + 1 < contentLen) {
-				extraPrefixes++;
-				nl = content.indexOf(0x0a, nl + 1);
-			}
-		}
-		const result = Buffer.allocUnsafe(
-			prefixLen + contentLen + prefixLen * extraPrefixes,
-		);
-		let writePos = prefixBuffer.copy(result, 0);
-		let readPos = 0;
-		while (readPos < contentLen) {
-			const nl = content.indexOf(0x0a, readPos);
-			const end = nl === -1 ? contentLen : nl + 1;
-			writePos += content.copy(result, writePos, readPos, end);
-			if (nl !== -1 && nl + 1 < contentLen) {
-				writePos += prefixBuffer.copy(result, writePos);
-			}
-			readPos = end;
-		}
-		return result;
-	}
-
-	/**
 	 * Returns a `Buffer[]` that concatenates to the prefixed source. Each
 	 * content chunk is a `subarray` of the underlying buffer (no copy);
-	 * only the prefix buffer is materialized.
+	 * only the prefix buffer is materialized. This skips both the regex
+	 * replace and the string-to-utf8 encoding that the default
+	 * `[this.buffer()]` path would do.
+	 *
+	 * `buffer()` itself stays on the `Source.prototype` default (which
+	 * goes through `this.source()` plus `Buffer.from`); benchmarking shows
+	 * V8's optimized string replace + utf8 encode beats a hand-written
+	 * single-pass copy here.
 	 * @returns {Buffer[]} buffers
 	 */
 	buffers() {

--- a/lib/PrefixSource.js
+++ b/lib/PrefixSource.js
@@ -65,13 +65,6 @@ class PrefixSource extends Source {
 	// TODO efficient buffer() implementation
 
 	/**
-	 * @returns {Buffer[]} buffers
-	 */
-	buffers() {
-		return [this.buffer()];
-	}
-
-	/**
 	 * @param {MapOptions=} options map options
 	 * @returns {RawSourceMap | null} map
 	 */

--- a/lib/PrefixSource.js
+++ b/lib/PrefixSource.js
@@ -9,6 +9,9 @@ const RawSource = require("./RawSource");
 const Source = require("./Source");
 const { getMap, getSourceAndMap } = require("./helpers/getFromStreamChunks");
 const streamChunks = require("./helpers/streamChunks");
+const {
+	isDualStringBufferCachingEnabled,
+} = require("./helpers/stringBufferUtils");
 
 /** @typedef {import("./Source").HashLike} HashLike */
 /** @typedef {import("./Source").MapOptions} MapOptions */
@@ -43,6 +46,16 @@ class PrefixSource extends Source {
 			typeof source === "string" || Buffer.isBuffer(source)
 				? new RawSource(source, true)
 				: source;
+		/**
+		 * @private
+		 * @type {Buffer | undefined}
+		 */
+		this._cachedBuffer = undefined;
+		/**
+		 * @private
+		 * @type {Buffer[] | undefined}
+		 */
+		this._cachedBuffers = undefined;
 	}
 
 	getPrefix() {
@@ -63,42 +76,61 @@ class PrefixSource extends Source {
 	}
 
 	/**
+	 * Cache the encoded buffer so repeat `buffer()` / `size()` calls don't
+	 * re-run the regex replace and re-encode the prefixed string. Mirrors
+	 * the `_valueAsBuffer` caching used by `RawSource`, `OriginalSource`,
+	 * and `SourceMapSource`. First call still goes through `this.source()`
+	 * plus `Buffer.from` because V8's string-replace + utf8 encode beats
+	 * a hand-written single-pass copy on typical ASCII inputs.
+	 * @returns {Buffer} buffer
+	 */
+	buffer() {
+		if (this._cachedBuffer !== undefined) return this._cachedBuffer;
+		const value = Buffer.from(/** @type {string} */ (this.source()), "utf8");
+		if (isDualStringBufferCachingEnabled()) {
+			this._cachedBuffer = value;
+		}
+		return value;
+	}
+
+	/**
 	 * Returns a `Buffer[]` that concatenates to the prefixed source. Each
 	 * content chunk is a `subarray` of the underlying buffer (no copy);
-	 * only the prefix buffer is materialized. This skips both the regex
-	 * replace and the string-to-utf8 encoding that the default
-	 * `[this.buffer()]` path would do.
-	 *
-	 * `buffer()` itself stays on the `Source.prototype` default (which
-	 * goes through `this.source()` plus `Buffer.from`); benchmarking shows
-	 * V8's optimized string replace + utf8 encode beats a hand-written
-	 * single-pass copy here.
+	 * only the prefix buffer is materialized. Cached for repeat calls.
 	 * @returns {Buffer[]} buffers
 	 */
 	buffers() {
+		if (this._cachedBuffers !== undefined) return this._cachedBuffers;
 		const prefix = this._prefix;
-		if (prefix.length === 0) {
-			const src = /** @type {Source} */ (this._source);
-			return src.buffers();
-		}
-		const content = this._source.buffer();
-		const prefixBuffer = Buffer.from(prefix, "utf8");
-		if (content.length === 0) return [prefixBuffer];
 		/** @type {Buffer[]} */
-		const result = [prefixBuffer];
-		const len = content.length;
-		let i = 0;
-		while (i < len) {
-			const nl = content.indexOf(0x0a, i);
-			if (nl === -1) {
-				result.push(i === 0 ? content : content.subarray(i));
-				return result;
+		let result;
+		if (prefix.length === 0) {
+			result = /** @type {Source} */ (this._source).buffers();
+		} else {
+			const content = this._source.buffer();
+			const prefixBuffer = Buffer.from(prefix, "utf8");
+			if (content.length === 0) {
+				result = [prefixBuffer];
+			} else {
+				result = [prefixBuffer];
+				const len = content.length;
+				let i = 0;
+				while (i < len) {
+					const nl = content.indexOf(0x0a, i);
+					if (nl === -1) {
+						result.push(i === 0 ? content : content.subarray(i));
+						break;
+					}
+					result.push(content.subarray(i, nl + 1));
+					// Match the regex `/\n(?=.|\s)/g` — only re-emit the prefix
+					// when at least one more byte follows the newline.
+					if (nl + 1 < len) result.push(prefixBuffer);
+					i = nl + 1;
+				}
 			}
-			result.push(content.subarray(i, nl + 1));
-			// Match the regex `/\n(?=.|\s)/g` — only re-emit the prefix when
-			// at least one more byte follows the newline.
-			if (nl + 1 < len) result.push(prefixBuffer);
-			i = nl + 1;
+		}
+		if (isDualStringBufferCachingEnabled()) {
+			this._cachedBuffers = result;
 		}
 		return result;
 	}

--- a/lib/RawSource.js
+++ b/lib/RawSource.js
@@ -82,6 +82,9 @@ class RawSource extends Source {
 		return this._value;
 	}
 
+	/**
+	 * @returns {Buffer} buffer
+	 */
 	buffer() {
 		if (this._valueAsBuffer === undefined) {
 			const value = Buffer.from(/** @type {string} */ (this._value), "utf8");
@@ -94,10 +97,7 @@ class RawSource extends Source {
 	}
 
 	/**
-	 * Override Source.prototype.size (= `this.buffer().length`) to avoid
-	 * allocating a Buffer just to read the byte length, and memoize the
-	 * result so repeated calls don't re-scan the string.
-	 * @returns {number} byte length
+	 * @returns {number} size
 	 */
 	size() {
 		if (this._cachedSize !== undefined) return this._cachedSize;

--- a/lib/RawSource.js
+++ b/lib/RawSource.js
@@ -94,6 +94,13 @@ class RawSource extends Source {
 	}
 
 	/**
+	 * @returns {Buffer[]} buffers
+	 */
+	buffers() {
+		return [this.buffer()];
+	}
+
+	/**
 	 * Override Source.prototype.size (= `this.buffer().length`) to avoid
 	 * allocating a Buffer just to read the byte length, and memoize the
 	 * result so repeated calls don't re-scan the string.

--- a/lib/RawSource.js
+++ b/lib/RawSource.js
@@ -94,13 +94,6 @@ class RawSource extends Source {
 	}
 
 	/**
-	 * @returns {Buffer[]} buffers
-	 */
-	buffers() {
-		return [this.buffer()];
-	}
-
-	/**
 	 * Override Source.prototype.size (= `this.buffer().length`) to avoid
 	 * allocating a Buffer just to read the byte length, and memoize the
 	 * result so repeated calls don't re-scan the string.

--- a/lib/ReplaceSource.js
+++ b/lib/ReplaceSource.js
@@ -193,6 +193,7 @@ class ReplaceSource extends Source {
 	 */
 	buffers() {
 		if (this._replacements.length === 0) {
+			// TODO remove in the next major release
 			return typeof this._source.buffers === "function"
 				? this._source.buffers()
 				: [this._source.buffer()];

--- a/lib/ReplaceSource.js
+++ b/lib/ReplaceSource.js
@@ -179,6 +179,28 @@ class ReplaceSource extends Source {
 	}
 
 	/**
+	 * @returns {Buffer} buffer
+	 */
+	buffer() {
+		if (this._replacements.length === 0) {
+			return this._source.buffer();
+		}
+		return super.buffer();
+	}
+
+	/**
+	 * @returns {Buffer[]} buffers
+	 */
+	buffers() {
+		if (this._replacements.length === 0) {
+			return typeof this._source.buffers === "function"
+				? this._source.buffers()
+				: [this._source.buffer()];
+		}
+		return [this.buffer()];
+	}
+
+	/**
 	 * @param {MapOptions=} options map options
 	 * @returns {RawSourceMap | null} map
 	 */

--- a/lib/SizeOnlySource.js
+++ b/lib/SizeOnlySource.js
@@ -31,6 +31,9 @@ class SizeOnlySource extends Source {
 		);
 	}
 
+	/**
+	 * @returns {number} size
+	 */
 	size() {
 		return this._size;
 	}

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -46,6 +46,9 @@ class Source {
 		throw new Error("Abstract");
 	}
 
+	/**
+	 * @returns {Buffer} buffer
+	 */
 	buffer() {
 		const source = this.source();
 		if (Buffer.isBuffer(source)) return source;
@@ -56,7 +59,9 @@ class Source {
 	 * @returns {Buffer[]} buffers
 	 */
 	buffers() {
-		return [this.buffer()];
+		const source = this.source();
+		if (Buffer.isBuffer(source)) return [source];
+		return [Buffer.from(source, "utf8")];
 	}
 
 	size() {

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -62,6 +62,9 @@ class Source {
 		return [this.buffer()];
 	}
 
+	/**
+	 * @returns {number} size
+	 */
 	size() {
 		return this.buffer().length;
 	}

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -59,9 +59,7 @@ class Source {
 	 * @returns {Buffer[]} buffers
 	 */
 	buffers() {
-		const source = this.source();
-		if (Buffer.isBuffer(source)) return [source];
-		return [Buffer.from(source, "utf8")];
+		return [this.buffer()];
 	}
 
 	size() {

--- a/lib/SourceMapSource.js
+++ b/lib/SourceMapSource.js
@@ -129,6 +129,9 @@ class SourceMapSource extends Source {
 		];
 	}
 
+	/**
+	 * @returns {Buffer} buffer
+	 */
 	buffer() {
 		if (this._valueAsBuffer === undefined) {
 			const value = Buffer.from(
@@ -144,10 +147,7 @@ class SourceMapSource extends Source {
 	}
 
 	/**
-	 * Override Source.prototype.size (= `this.buffer().length`) to avoid
-	 * allocating a Buffer just to read the byte length, and memoize the
-	 * result so repeated calls don't re-scan the string.
-	 * @returns {number} byte length
+	 * @returns {number} size
 	 */
 	size() {
 		if (this._cachedSize !== undefined) return this._cachedSize;

--- a/lib/SourceMapSource.js
+++ b/lib/SourceMapSource.js
@@ -144,6 +144,13 @@ class SourceMapSource extends Source {
 	}
 
 	/**
+	 * @returns {Buffer[]} buffers
+	 */
+	buffers() {
+		return [this.buffer()];
+	}
+
+	/**
 	 * Override Source.prototype.size (= `this.buffer().length`) to avoid
 	 * allocating a Buffer just to read the byte length, and memoize the
 	 * result so repeated calls don't re-scan the string.

--- a/lib/SourceMapSource.js
+++ b/lib/SourceMapSource.js
@@ -144,13 +144,6 @@ class SourceMapSource extends Source {
 	}
 
 	/**
-	 * @returns {Buffer[]} buffers
-	 */
-	buffers() {
-		return [this.buffer()];
-	}
-
-	/**
 	 * Override Source.prototype.size (= `this.buffer().length`) to avoid
 	 * allocating a Buffer just to read the byte length, and memoize the
 	 * result so repeated calls don't re-scan the string.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webpack-sources",
-  "version": "3.3.4",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webpack-sources",
-      "version": "3.3.4",
+      "version": "3.4.0",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.30.0",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
   "name": "webpack-sources",
   "version": "3.4.0",
   "description": "Source code handling classes for webpack",
-  "keywords": [
-    "webpack",
-    "source-map"
-  ],
+  "keywords": ["webpack", "source-map"],
   "homepage": "https://github.com/webpack/webpack-sources#readme",
   "bugs": {
     "url": "https://github.com/webpack/webpack-sources/issues"
@@ -18,10 +15,7 @@
   "author": "Tobias Koppers @sokra",
   "main": "lib/index.js",
   "types": "types.d.ts",
-  "files": [
-    "lib/",
-    "types.d.ts"
-  ],
+  "files": ["lib/", "types.d.ts"],
   "scripts": {
     "lint": "npm run lint:code && npm run lint:types && npm run lint:types-test && npm run lint:special",
     "lint:code": "eslint --cache .",

--- a/test/OriginalSource.js
+++ b/test/OriginalSource.js
@@ -107,6 +107,23 @@ describe.each([
 		expect(source.getName()).toBe("file.js");
 	});
 
+	it("should expose buffers() returning a single-entry Buffer[]", () => {
+		const content = "Line1\nLine2\n";
+		const source = new OriginalSource(content, "file.js");
+		const buffers = source.buffers();
+		expect(Array.isArray(buffers)).toBe(true);
+		expect(buffers).toHaveLength(1);
+		expect(buffers[0]).toEqual(Buffer.from(content));
+	});
+
+	it("should reuse the underlying buffer in buffers() when constructed from a Buffer", () => {
+		const buffer = Buffer.from("Line1\nLine2\n");
+		const source = new OriginalSource(buffer, "file.js");
+		const buffers = source.buffers();
+		expect(buffers).toHaveLength(1);
+		expect(buffers[0]).toBe(buffer);
+	});
+
 	it("should compute map correctly from buffer-backed source", () => {
 		const content = "Line1\nLine2\n";
 		const source = new OriginalSource(Buffer.from(content), "file.js");

--- a/test/PrefixSource.js
+++ b/test/PrefixSource.js
@@ -7,6 +7,7 @@ const { PrefixSource } = require("../");
 const { OriginalSource } = require("../");
 const { ConcatSource } = require("../");
 const { RawSource } = require("../");
+const { ReplaceSource } = require("../");
 const { withReadableMappings } = require("./helpers");
 
 describe("prefixSource", () => {
@@ -209,5 +210,23 @@ describe("prefixSource", () => {
 		const source = new PrefixSource("> ", new RawSource("héllo\nwörld"));
 		expect(source.buffer().toString("utf8")).toBe("> héllo\n> wörld");
 		expect(source.buffer().toString("utf8")).toBe(source.source());
+	});
+
+	it("should reflect mutations to the underlying source on subsequent calls", () => {
+		const inner = new ReplaceSource(new RawSource("hello world"));
+		const source = new PrefixSource("> ", inner);
+		expect(source.source()).toBe("> hello world");
+		expect(source.buffer().toString("utf8")).toBe("> hello world");
+		expect(Buffer.concat(source.buffers()).toString("utf8")).toBe(
+			"> hello world",
+		);
+
+		inner.replace(6, 10, "you");
+
+		expect(source.source()).toBe("> hello you");
+		expect(source.buffer().toString("utf8")).toBe("> hello you");
+		expect(Buffer.concat(source.buffers()).toString("utf8")).toBe(
+			"> hello you",
+		);
 	});
 });

--- a/test/PrefixSource.js
+++ b/test/PrefixSource.js
@@ -170,12 +170,44 @@ describe("prefixSource", () => {
 		expect(source.sourceAndMap().source).toBe("hello\nworld\n");
 	});
 
-	it("should expose buffers() returning the prefixed source as a single buffer", () => {
+	it("should expose buffers() that concatenates to the prefixed source", () => {
 		const source = new PrefixSource("> ", new RawSource("hello\nworld"));
 		const buffers = source.buffers();
 		expect(Array.isArray(buffers)).toBe(true);
-		expect(buffers).toHaveLength(1);
-		expect(buffers[0]).toEqual(Buffer.from("> hello\n> world"));
+		expect(Buffer.concat(buffers)).toEqual(Buffer.from("> hello\n> world"));
 		expect(Buffer.concat(buffers)).toEqual(source.buffer());
+		expect(source.buffer().toString("utf8")).toBe(source.source());
+	});
+
+	it("should not emit a trailing prefix buffer when source ends with a newline", () => {
+		const source = new PrefixSource("> ", new RawSource("a\n"));
+		expect(source.buffer().toString("utf8")).toBe("> a\n");
+		expect(source.buffer().toString("utf8")).toBe(source.source());
+	});
+
+	it("should emit prefix between consecutive newlines", () => {
+		const source = new PrefixSource("> ", new RawSource("a\n\nb"));
+		expect(source.buffer().toString("utf8")).toBe("> a\n> \n> b");
+		expect(source.buffer().toString("utf8")).toBe(source.source());
+	});
+
+	it("should pass through underlying buffers when prefix is empty", () => {
+		const inner = new RawSource(Buffer.from("hello"));
+		const source = new PrefixSource("", inner);
+		const buffers = source.buffers();
+		expect(buffers).toHaveLength(1);
+		expect(buffers[0]).toBe(inner.buffer());
+	});
+
+	it("should produce just the prefix when underlying source is empty", () => {
+		const source = new PrefixSource("> ", new RawSource(""));
+		expect(source.buffer().toString("utf8")).toBe("> ");
+		expect(source.buffer().toString("utf8")).toBe(source.source());
+	});
+
+	it("should handle multi-byte utf-8 across newlines", () => {
+		const source = new PrefixSource("> ", new RawSource("héllo\nwörld"));
+		expect(source.buffer().toString("utf8")).toBe("> héllo\n> wörld");
+		expect(source.buffer().toString("utf8")).toBe(source.source());
 	});
 });

--- a/test/PrefixSource.js
+++ b/test/PrefixSource.js
@@ -169,4 +169,13 @@ describe("prefixSource", () => {
 		expect(source.source()).toBe("hello\nworld\n");
 		expect(source.sourceAndMap().source).toBe("hello\nworld\n");
 	});
+
+	it("should expose buffers() returning the prefixed source as a single buffer", () => {
+		const source = new PrefixSource("> ", new RawSource("hello\nworld"));
+		const buffers = source.buffers();
+		expect(Array.isArray(buffers)).toBe(true);
+		expect(buffers).toHaveLength(1);
+		expect(buffers[0]).toEqual(Buffer.from("> hello\n> world"));
+		expect(Buffer.concat(buffers)).toEqual(source.buffer());
+	});
 });

--- a/test/RawSource.js
+++ b/test/RawSource.js
@@ -166,4 +166,21 @@ describe("rawSource", () => {
 			expect(source.source().toString("utf8")).toEqual(CODE_STRING);
 		});
 	});
+
+	it("should expose buffers() returning a single-entry Buffer[]", () => {
+		const source = new RawSource(CODE_STRING);
+		const buffers = source.buffers();
+		expect(Array.isArray(buffers)).toBe(true);
+		expect(buffers).toHaveLength(1);
+		expect(buffers[0]).toEqual(Buffer.from(CODE_STRING));
+		expect(Buffer.concat(buffers)).toEqual(source.buffer());
+	});
+
+	it("should reuse the underlying buffer in buffers() when constructed from a Buffer", () => {
+		const buffer = Buffer.from(CODE_STRING);
+		const source = new RawSource(buffer);
+		const buffers = source.buffers();
+		expect(buffers).toHaveLength(1);
+		expect(buffers[0]).toBe(buffer);
+	});
 });

--- a/test/ReplaceSource.js
+++ b/test/ReplaceSource.js
@@ -451,4 +451,23 @@ export default function StaticPage(_ref) {
 		expect(source.source()).toBe("Hello You");
 		expect(source.sourceAndMap()).toHaveProperty("source", "Hello You");
 	});
+
+	it("should expose buffers() reflecting the replaced source", () => {
+		const source = new ReplaceSource(new RawSource("Hello World"));
+		source.replace(6, 10, "You");
+		const buffers = source.buffers();
+		expect(Array.isArray(buffers)).toBe(true);
+		expect(buffers).toHaveLength(1);
+		expect(buffers[0]).toEqual(Buffer.from("Hello You"));
+		expect(Buffer.concat(buffers)).toEqual(source.buffer());
+	});
+
+	it("should delegate buffers() to the underlying source when no replacements", () => {
+		const inner = new RawSource(Buffer.from("untouched"));
+		const source = new ReplaceSource(inner);
+		const buffers = source.buffers();
+		expect(buffers).toHaveLength(1);
+		expect(buffers[0]).toBe(inner.buffer());
+		expect(source.buffer()).toBe(inner.buffer());
+	});
 });

--- a/test/Source.js
+++ b/test/Source.js
@@ -86,4 +86,17 @@ describe("source", () => {
 		expect(buffers).toHaveLength(1);
 		expect(buffers[0]).toEqual(Buffer.from("dummy", "utf8"));
 	});
+
+	it("should return the buffer directly from buffers() when source is a buffer", () => {
+		const buffer = Buffer.from([1, 2, 3]);
+		class DummySource extends Source {
+			source() {
+				return buffer;
+			}
+		}
+		const source = new DummySource();
+		const buffers = source.buffers();
+		expect(buffers).toHaveLength(1);
+		expect(buffers[0]).toBe(buffer);
+	});
 });

--- a/test/SourceMapSource.js
+++ b/test/SourceMapSource.js
@@ -578,6 +578,23 @@ describe.each([
 		expect(buffer2).toBe(buffer1);
 	});
 
+	it("should expose buffers() returning a single-entry Buffer[]", () => {
+		const sourceMapSource = new SourceMapSource("source", "name");
+		const buffers = sourceMapSource.buffers();
+		expect(Array.isArray(buffers)).toBe(true);
+		expect(buffers).toHaveLength(1);
+		expect(buffers[0]).toEqual(Buffer.from("source"));
+		expect(Buffer.concat(buffers)).toEqual(sourceMapSource.buffer());
+	});
+
+	it("should reuse the underlying buffer in buffers() when constructed from a Buffer", () => {
+		const buffer = Buffer.from("source", "utf8");
+		const sourceMapSource = new SourceMapSource(buffer, "name");
+		const buffers = sourceMapSource.buffers();
+		expect(buffers).toHaveLength(1);
+		expect(buffers[0]).toBe(buffer);
+	});
+
 	it("should accept source map as string", () => {
 		const mapObj = {
 			version: 3,


### PR DESCRIPTION
Extend the buffers() API to every concrete Source class so callers always
get a Buffer[] without falling back to the abstract Source default. Each
single-buffer-backed class returns [this.buffer()]. ReplaceSource
delegates to the underlying source's buffers() when no replacements are
queued and otherwise materializes the replaced source into a single
buffer.

https://claude.ai/code/session_01EHhGq9PRFRGefVtwwasCqZ