### PR TITLE
ci(benchmarks): align github actions permissions between the two benchmarks jobs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,14 +11,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  id-token: write # Required for OIDC authentication with CodSpeed
-
 jobs:
   benchmark:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
+      id-token: write # Required for OIDC authentication with CodSpeed
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -43,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Required for OIDC authentication with CodSpeed
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
**Summary**

Hello, CodSpeed team member here. We noticed that many of you recent benchmarks were failing on CodSpeed because of a mismatch between the authentication methods used by your two benchmarks jobs.

The two benchmarks jobs need the same permissions to run the benchmarks and upload to CodSpeed. However, the previous configuration was overriding the `id-token: write` permissions for the `benchmark` job. This caused the upload to CodSpeed to fail.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

This PR aligns the permissions given to both benchmarks jobs. Also since these two jobs are the only ones in the workflow, we can safely remove the top-level permissions.

Note: it is generally considered best-practice to scope the github permissions at the job level, even if it introduces a bit of duplication. However in this case, since there are only two jobs that have the same permissions, it could be ok to only have a top-level permissions bock. Let me know if you prefer that.

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

No, this is a config only change.

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Nothing
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

No

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->