### PR TITLE
perf: track sorted state incrementally in ReplaceSource

### DIFF
--- a/.changeset/replace-source-incremental-sort.md
+++ b/.changeset/replace-source-incremental-sort.md
@@ -1,0 +1,7 @@
+---
+"webpack-sources": patch
+---
+
+perf: track sorted state incrementally in ReplaceSource replace/insert
+
+Instead of unconditionally marking the array as unsorted on every replace/insert call, compare the new element against the last one. When replacements are added in source order (the common case in webpack), the array stays marked as sorted and _sortReplacements() becomes a no-op.

--- a/lib/ReplaceSource.js
+++ b/lib/ReplaceSource.js
@@ -127,8 +127,14 @@ class ReplaceSource extends Source {
 				`insertion must be a string, but is a ${typeof newValue}`,
 			);
 		}
-		this._replacements.push(new Replacement(start, end, newValue, name));
-		this._isSorted = false;
+		const arr = this._replacements;
+		if (this._isSorted && arr.length > 0) {
+			const last = arr[arr.length - 1];
+			if (start < last.start || (start === last.start && end < last.end)) {
+				this._isSorted = false;
+			}
+		}
+		arr.push(new Replacement(start, end, newValue, name));
 	}
 
 	/**
@@ -143,8 +149,15 @@ class ReplaceSource extends Source {
 				`insertion must be a string, but is a ${typeof newValue}: ${newValue}`,
 			);
 		}
-		this._replacements.push(new Replacement(pos, pos - 1, newValue, name));
-		this._isSorted = false;
+		const arr = this._replacements;
+		if (this._isSorted && arr.length > 0) {
+			const last = arr[arr.length - 1];
+			const end = pos - 1;
+			if (pos < last.start || (pos === last.start && end < last.end)) {
+				this._isSorted = false;
+			}
+		}
+		arr.push(new Replacement(pos, pos - 1, newValue, name));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Instead of unconditionally setting `_isSorted = false` on every `replace()`/`insert()` call, compare the new element against the last one
- When replacements are added in source order (the common case in webpack, since AST traversal is position-ordered), the array stays marked as sorted and `_sortReplacements()` becomes a no-op flag check
- For genuinely unordered input, behavior is identical to before — the flag gets set to `false` and the normal `Array.prototype.sort()` runs

## Benchmark results (ops/s, higher is better)

| Benchmark | Before | After | Change |
|---|---|---|---|
| getReplacements() | 7,637 | 13,643 | **+78.7%** |
| source() (1 replacement) | 101,919 | 107,040 | **+5.0%** |
| source() (1000 small replacements) | 6,135 | 6,609 | **+7.7%** |
| source() (few large replacements) | 10,158 | 10,497 | **+3.3%** |
| replace() x1000 | 244,693 | 218,742 | -10.6% |
| insert() x1000 | 244,665 | 216,147 | -11.7% |

The `replace()`/`insert()` per-call overhead (~11ns) is a deliberate trade-off: downstream consumers (`source()`, `map()`, `streamChunks()`) skip an entire O(n log n) sort when data is already ordered.

All 89,869 tests pass.

## Test plan

- [x] `yarn lint` passes
- [x] `npx jest --no-coverage` — 89,869 tests pass
- [x] Benchmark verified with `npm run benchmark`

🤖 Generated with [Claude Code](https://claude.com/claude-code)