### PR TITLE
perf: skip sorting ReplaceSource replacements when already in order

### DIFF
--- a/.changeset/replace-source-skip-presorted-sort.md
+++ b/.changeset/replace-source-skip-presorted-sort.md
@@ -1,0 +1,5 @@
+---
+"webpack-sources": patch
+---
+
+Skip sorting ReplaceSource replacements when they were added in order.

--- a/lib/ReplaceSource.js
+++ b/lib/ReplaceSource.js
@@ -235,6 +235,26 @@ class ReplaceSource extends Source {
 
 	_sortReplacements() {
 		if (this._isSorted) return;
+		const replacements = this._replacements;
+		// Replacements are usually appended in source order (ties keep
+		// insertion order, matching a stable sort), so an O(n) pre-scan
+		// often lets us skip the sort and its per-element comparator calls.
+		let isPresorted = true;
+		for (let i = 1; i < replacements.length; i++) {
+			const prev = replacements[i - 1];
+			const repl = replacements[i];
+			if (
+				repl.start < prev.start ||
+				(repl.start === prev.start && repl.end < prev.end)
+			) {
+				isPresorted = false;
+				break;
+			}
+		}
+		if (isPresorted) {
+			this._isSorted = true;
+			return;
+		}
 		if (hasStableSort) {
 			this._replacements.sort(compareStable);
 		} else {

--- a/test/ReplaceSource.js
+++ b/test/ReplaceSource.js
@@ -347,6 +347,64 @@ export default function StaticPage(_ref) {
 		expect(replacements[1].content).toBe("Claude");
 	});
 
+	it("should skip sorting when replacements were added in order", () => {
+		const source = new ReplaceSource(
+			new OriginalSource("Hello World", "file.txt"),
+		);
+		source.replace(0, 4, "Howdy");
+		source.replace(6, 10, "Claude");
+		const sortSpy = jest.spyOn(Array.prototype, "sort");
+		try {
+			expect(source.source()).toBe("Howdy Claude");
+			expect(sortSpy).not.toHaveBeenCalled();
+		} finally {
+			sortSpy.mockRestore();
+		}
+	});
+
+	it("should sort when replacements were added out of order", () => {
+		const source = new ReplaceSource(
+			new OriginalSource("Hello World", "file.txt"),
+		);
+		source.replace(6, 10, "Claude");
+		source.replace(0, 4, "Howdy");
+		const sortSpy = jest.spyOn(Array.prototype, "sort");
+		try {
+			expect(source.source()).toBe("Howdy Claude");
+			expect(sortSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			sortSpy.mockRestore();
+		}
+	});
+
+	it("should re-sort when a replacement is added out of order after a read", () => {
+		const source = new ReplaceSource(
+			new OriginalSource("Hello World", "file.txt"),
+		);
+		source.replace(6, 10, "Claude");
+		expect(source.source()).toBe("Hello Claude");
+		source.replace(0, 4, "Howdy");
+		expect(source.source()).toBe("Howdy Claude");
+	});
+
+	it("should keep insertion order for replacements at the same position", () => {
+		const inOrder = new ReplaceSource(
+			new OriginalSource("Hello World", "file.txt"),
+		);
+		inOrder.insert(5, " first");
+		inOrder.insert(5, " second");
+		expect(inOrder.source()).toBe("Hello first second World");
+
+		// same ties, but with an out-of-order append forcing a real sort
+		const sorted = new ReplaceSource(
+			new OriginalSource("Hello World", "file.txt"),
+		);
+		sorted.insert(5, " first");
+		sorted.insert(5, " second");
+		sorted.replace(0, 4, "Howdy");
+		expect(sorted.source()).toBe("Howdy first second World");
+	});
+
 	it("should throw when replace() gets non-string newValue", () => {
 		const source = new ReplaceSource(
 			new OriginalSource("Hello World", "file.txt"),


### PR DESCRIPTION
Replacements are usually appended in source order, so _sortReplacements now does an O(n) early-exit pre-scan and skips the stable sort (and its per-element comparator calls) when the array is already sorted. The push path is unchanged; map/sourceAndMap/streamChunks/getReplacements/ updateHash improve 8-14% on the replace-source benchmark.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->