### PR TITLE
feat: emit the source map scopes field

### DIFF
--- a/.changeset/source-map-scopes.md
+++ b/.changeset/source-map-scopes.md
@@ -1,0 +1,5 @@
+---
+"webpack-sources": minor
+---
+
+Add `map({ scopes: true })`, emitting the source map `scopes` field from the bindings a source declares.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Returns the SourceMap of the represented source code as JSON. May return `null` 
 The `options` object can contain the following keys:
 
 - `columns: Boolean` (default `true`): If set to false the implementation may omit mappings for columns.
+- `scopes: Boolean` (default `false`): If set to true the map carries the `scopes` field of the [Scopes proposal](https://github.com/tc39/ecma426/blob/main/proposals/scopes.md), naming for each source the bindings it declares and the expression each one reads in the generated code. Sources declare those bindings themselves — see `OriginalSource` — and a map whose sources declare none omits the field.
 
 #### `sourceAndMap`
 
@@ -105,12 +106,14 @@ Represents source code, which is a copy of the original file.
 ```typescript
 new OriginalSource(
 	sourceCode: String | Buffer,
-	name: String
+	name: String,
+	scopeBindings?: Map<String, String>
 )
 ```
 
 - `sourceCode`: The source code.
 - `name`: The filename of the original source code.
+- `scopeBindings`: What each name this source declares reads in the generated code, keyed by the name the source uses. Only consulted when a map is asked for with `scopes: true`, and carried through wrapping sources such as `ReplaceSource` and `ConcatSource`.
 
 OriginalSource tries to create column mappings if requested, by splitting the source code at typical statement borders (`;`, `{`, `}`).
 

--- a/lib/CachedSource.js
+++ b/lib/CachedSource.js
@@ -99,7 +99,8 @@ const getCacheKey = (options) => {
 	if (
 		/** @type {Options} */ (options).source === undefined &&
 		/** @type {Options} */ (options).finalSource === undefined &&
-		/** @type {MapOptions} */ (options).module === undefined
+		/** @type {MapOptions} */ (options).module === undefined &&
+		/** @type {MapOptions} */ (options).scopes === undefined
 	) {
 		if (columns === undefined) return CACHE_KEY_EMPTY;
 		return columns ? CACHE_KEY_COLUMNS_TRUE : CACHE_KEY_COLUMNS_FALSE;

--- a/lib/ConcatSource.js
+++ b/lib/ConcatSource.js
@@ -279,11 +279,11 @@ class ConcatSource extends Source {
 						);
 					}
 				},
-				(i, source, sourceContent) => {
+				(i, source, sourceContent, scopeBindings) => {
 					let globalIndex = sourceMapping.get(source);
 					if (globalIndex === undefined) {
 						sourceMapping.set(source, (globalIndex = sourceMapping.size));
-						onSource(globalIndex, source, sourceContent);
+						onSource(globalIndex, source, sourceContent, scopeBindings);
 					}
 					sourceIndexMapping[i] = globalIndex;
 				},

--- a/lib/OriginalSource.js
+++ b/lib/OriginalSource.js
@@ -24,13 +24,16 @@ const {
 /** @typedef {import("./helpers/streamChunks").OnName} OnName */
 /** @typedef {import("./helpers/streamChunks").OnSource} OnSource */
 /** @typedef {import("./helpers/streamChunks").Options} Options */
+/** @typedef {import("./helpers/streamChunks").ScopeBindings} ScopeBindings */
 
 class OriginalSource extends Source {
 	/**
 	 * @param {string | Buffer} value value
 	 * @param {string} name name
+	 * @param {ScopeBindings=} scopeBindings what each name this source declares
+	 * evaluates to in the generated code, for the map's `scopes` field
 	 */
-	constructor(value, name) {
+	constructor(value, name, scopeBindings) {
 		super();
 
 		const isBuffer = Buffer.isBuffer(value);
@@ -50,6 +53,11 @@ class OriginalSource extends Source {
 		 * @type {string}
 		 */
 		this._name = name;
+		/**
+		 * @private
+		 * @type {undefined | ScopeBindings}
+		 */
+		this._scopeBindings = scopeBindings;
 	}
 
 	getName() {
@@ -129,7 +137,7 @@ class OriginalSource extends Source {
 				/** @type {Buffer} */
 				(this._valueAsBuffer).toString("utf8");
 		}
-		onSource(0, this._name, this._value);
+		onSource(0, this._name, this._value, this._scopeBindings);
 		const finalSource = Boolean(options && options.finalSource);
 		if (!options || options.columns !== false) {
 			// With column info we need to walk every potential token. The

--- a/lib/ReplaceSource.js
+++ b/lib/ReplaceSource.js
@@ -610,13 +610,13 @@ class ReplaceSource extends Source {
 				}
 				pos = endPos;
 			},
-			(sourceIndex, source, sourceContent) => {
+			(sourceIndex, source, sourceContent, scopeBindings) => {
 				/* istanbul ignore next: non-sequential sourceIndex emission is not produced by any in-tree Source */
 				while (sourceContents.length < sourceIndex) {
 					sourceContents.push(undefined);
 				}
 				sourceContents[sourceIndex] = sourceContent;
-				onSource(sourceIndex, source, sourceContent);
+				onSource(sourceIndex, source, sourceContent, scopeBindings);
 			},
 			(nameIndex, name) => {
 				let globalIndex = nameMapping.get(name);

--- a/lib/Source.js
+++ b/lib/Source.js
@@ -9,6 +9,7 @@
  * @typedef {object} MapOptions
  * @property {boolean=} columns need columns?
  * @property {boolean=} module is module
+ * @property {boolean=} scopes emit the `scopes` field from the bindings the sources declare
  */
 
 /**
@@ -22,6 +23,7 @@
  * @property {string} file file
  * @property {string=} debugId debug id
  * @property {number[]=} ignoreList ignore list
+ * @property {string=} scopes encoded `scopes` field of the "Scopes" proposal
  */
 
 /** @typedef {string | Buffer} SourceValue */

--- a/lib/helpers/getFromStreamChunks.js
+++ b/lib/helpers/getFromStreamChunks.js
@@ -66,34 +66,53 @@ module.exports.getMap = (source, options) => {
 	const addMapping = mappingsWriter.add;
 	const scopesWriter =
 		options && options.scopes ? createScopesWriter() : undefined;
+	// Chosen once rather than tested per segment: this callback is the whole of
+	// the mapping loop, so a branch in it is measurable on every map built.
 	const generated = source.streamChunks(
 		{ ...options, source: false, finalSource: true },
-		(
-			chunk,
-			generatedLine,
-			generatedColumn,
-			sourceIndex,
-			originalLine,
-			originalColumn,
-			nameIndex,
-		) => {
-			addMapping(
-				generatedLine,
-				generatedColumn,
-				sourceIndex,
-				originalLine,
-				originalColumn,
-				nameIndex,
-			);
-			if (scopesWriter !== undefined) {
-				scopesWriter.add(
+		scopesWriter === undefined
+			? (
+					chunk,
 					generatedLine,
 					generatedColumn,
 					sourceIndex,
 					originalLine,
-				);
-			}
-		},
+					originalColumn,
+					nameIndex,
+				) => {
+					addMapping(
+						generatedLine,
+						generatedColumn,
+						sourceIndex,
+						originalLine,
+						originalColumn,
+						nameIndex,
+					);
+				}
+			: (
+					chunk,
+					generatedLine,
+					generatedColumn,
+					sourceIndex,
+					originalLine,
+					originalColumn,
+					nameIndex,
+				) => {
+					addMapping(
+						generatedLine,
+						generatedColumn,
+						sourceIndex,
+						originalLine,
+						originalColumn,
+						nameIndex,
+					);
+					scopesWriter.add(
+						generatedLine,
+						generatedColumn,
+						sourceIndex,
+						originalLine,
+					);
+				},
 		(sourceIndex, source, sourceContent, scopeBindings) => {
 			setAtIndex(potentialSources, sourceIndex, source);
 			if (sourceContent !== undefined) {

--- a/lib/helpers/getFromStreamChunks.js
+++ b/lib/helpers/getFromStreamChunks.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const { createMappingsWriter } = require("./createMappingsSerializer");
+const { createScopesWriter } = require("./scopes");
 
 /** @typedef {import("../Source").RawSourceMap} RawSourceMap */
 /** @typedef {import("../Source").SourceAndMap} SourceAndMap */
@@ -50,7 +51,9 @@ module.exports.getMap = (source, options) => {
 	const potentialNames = [];
 	const mappingsWriter = createMappingsWriter(options);
 	const addMapping = mappingsWriter.add;
-	source.streamChunks(
+	const scopesWriter =
+		options && options.scopes ? createScopesWriter() : undefined;
+	const generated = source.streamChunks(
 		{ ...options, source: false, finalSource: true },
 		(
 			chunk,
@@ -69,11 +72,22 @@ module.exports.getMap = (source, options) => {
 				originalColumn,
 				nameIndex,
 			);
+			if (scopesWriter !== undefined) {
+				scopesWriter.add(
+					generatedLine,
+					generatedColumn,
+					sourceIndex,
+					originalLine,
+				);
+			}
 		},
-		(sourceIndex, source, sourceContent) => {
+		(sourceIndex, source, sourceContent, scopeBindings) => {
 			setAtIndex(potentialSources, sourceIndex, source);
 			if (sourceContent !== undefined) {
 				setAtIndex(potentialSourcesContent, sourceIndex, sourceContent);
+			}
+			if (scopesWriter !== undefined) {
+				scopesWriter.addSource(sourceIndex, scopeBindings);
 			}
 		},
 		(nameIndex, name) => {
@@ -81,20 +95,24 @@ module.exports.getMap = (source, options) => {
 		},
 	);
 	const mappings = mappingsWriter.finish();
-	return mappings.length > 0
-		? {
-				version: 3,
-				file: "x",
-				mappings,
-				// We handle broken sources as `null`, in spec this field should be string, but no information what we should do in such cases if we change type it will be breaking change
-				sources: /** @type {string[]} */ (potentialSources),
-				sourcesContent:
-					potentialSourcesContent.length > 0
-						? /** @type {string[]} */ (potentialSourcesContent)
-						: undefined,
-				names: /** @type {string[]} */ (potentialNames),
-			}
-		: null;
+	if (mappings.length === 0) return null;
+	/** @type {RawSourceMap} */
+	const map = {
+		version: 3,
+		file: "x",
+		mappings,
+		// We handle broken sources as `null`, in spec this field should be string, but no information what we should do in such cases if we change type it will be breaking change
+		sources: /** @type {string[]} */ (potentialSources),
+		sourcesContent:
+			potentialSourcesContent.length > 0
+				? /** @type {string[]} */ (potentialSourcesContent)
+				: undefined,
+		names: /** @type {string[]} */ (potentialNames),
+	};
+	if (scopesWriter !== undefined) {
+		scopesWriter.finish(map, generated.generatedLine);
+	}
+	return map;
 };
 
 /**
@@ -112,7 +130,9 @@ module.exports.getSourceAndMap = (inputSource, options) => {
 	const potentialNames = [];
 	const mappingsWriter = createMappingsWriter(options);
 	const addMapping = mappingsWriter.add;
-	const { source } = inputSource.streamChunks(
+	const scopesWriter =
+		options && options.scopes ? createScopesWriter() : undefined;
+	const generated = inputSource.streamChunks(
 		// `source: true` overrides any `source: false` a caller forwarded
 		// (e.g. the streamChunks fallback passing getMap options through
 		// sourceAndMap) — this helper always consumes the source.
@@ -135,8 +155,19 @@ module.exports.getSourceAndMap = (inputSource, options) => {
 				originalColumn,
 				nameIndex,
 			);
+			if (scopesWriter !== undefined) {
+				scopesWriter.add(
+					generatedLine,
+					generatedColumn,
+					sourceIndex,
+					originalLine,
+				);
+			}
 		},
-		(sourceIndex, source, sourceContent) => {
+		(sourceIndex, source, sourceContent, scopeBindings) => {
+			if (scopesWriter !== undefined) {
+				scopesWriter.addSource(sourceIndex, scopeBindings);
+			}
 			while (potentialSources.length < sourceIndex) {
 				potentialSources.push(null);
 			}
@@ -156,22 +187,25 @@ module.exports.getSourceAndMap = (inputSource, options) => {
 		},
 	);
 	const mappings = mappingsWriter.finish();
-	return {
-		source: source !== undefined ? source : code,
-		map:
-			mappings.length > 0
-				? {
-						version: 3,
-						file: "x",
-						mappings,
-						// We handle broken sources as `null`, in spec this field should be string, but no information what we should do in such cases if we change type it will be breaking change
-						sources: /** @type {string[]} */ (potentialSources),
-						sourcesContent:
-							potentialSourcesContent.length > 0
-								? /** @type {string[]} */ (potentialSourcesContent)
-								: undefined,
-						names: /** @type {string[]} */ (potentialNames),
-					}
-				: null,
-	};
+	const { source } = generated;
+	/** @type {RawSourceMap | null} */
+	let map = null;
+	if (mappings.length > 0) {
+		map = {
+			version: 3,
+			file: "x",
+			mappings,
+			// We handle broken sources as `null`, in spec this field should be string, but no information what we should do in such cases if we change type it will be breaking change
+			sources: /** @type {string[]} */ (potentialSources),
+			sourcesContent:
+				potentialSourcesContent.length > 0
+					? /** @type {string[]} */ (potentialSourcesContent)
+					: undefined,
+			names: /** @type {string[]} */ (potentialNames),
+		};
+		if (scopesWriter !== undefined) {
+			scopesWriter.finish(map, generated.generatedLine);
+		}
+	}
+	return { source: source !== undefined ? source : code, map };
 };

--- a/lib/helpers/getFromStreamChunks.js
+++ b/lib/helpers/getFromStreamChunks.js
@@ -6,7 +6,6 @@
 "use strict";
 
 const { createMappingsWriter } = require("./createMappingsSerializer");
-const { createScopesWriter } = require("./scopes");
 
 /** @typedef {import("../Source").RawSourceMap} RawSourceMap */
 /** @typedef {import("../Source").SourceAndMap} SourceAndMap */
@@ -14,6 +13,20 @@ const { createScopesWriter } = require("./scopes");
 /** @typedef {import("./streamChunks").StreamChunksFunction} StreamChunksFunction */
 
 /** @typedef {{ streamChunks: StreamChunksFunction }} SourceLikeWithStreamChunks */
+
+/** @type {typeof import("./scopes") | undefined} */
+let scopesHelpers;
+
+/**
+ * Loads the scopes helpers on first use. They are only reachable through the
+ * `scopes` option, so requiring them eagerly would put the encoder in the
+ * module graph of every caller that never asks for the field.
+ * @returns {ReturnType<typeof import("./scopes").createScopesWriter>} writer
+ */
+const createScopesWriter = () => {
+	if (scopesHelpers === undefined) scopesHelpers = require("./scopes");
+	return scopesHelpers.createScopesWriter();
+};
 
 /**
  * Assign `value` at index `i` of `arr`, padding earlier slots with `null`.

--- a/lib/helpers/scopes.js
+++ b/lib/helpers/scopes.js
@@ -1,0 +1,437 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Alexander Akait @alexander-akait
+*/
+
+"use strict";
+
+/** @typedef {import("../Source").RawSourceMap} RawSourceMap */
+/** @typedef {import("./streamChunks").ScopeBindings} ScopeBindings */
+
+/**
+ * A generated or original position, both counted from zero.
+ * @typedef {object} ScopePosition
+ * @property {number} line line
+ * @property {number} column column
+ */
+
+/**
+ * One source's scope, and the span of generated code it explains.
+ * @typedef {object} SourceScope
+ * @property {number} sourceIndex index into the map's `sources`
+ * @property {string[]} variables the names the source declares
+ * @property {string[]} values the generated expression each name evaluates to
+ * @property {ScopePosition} originalEnd end of the original scope, exclusive
+ * @property {ScopePosition[]} rangeStarts start of each generated range, inclusive
+ * @property {ScopePosition[]} rangeEnds end of each generated range, exclusive
+ */
+
+const BASE64_CHARS =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+const BASE64_VALUES = new Int8Array(128).fill(-1);
+for (let index = 0; index < BASE64_CHARS.length; index++) {
+	BASE64_VALUES[BASE64_CHARS.charCodeAt(index)] = index;
+}
+
+const VLQ_BASE_SHIFT = 5;
+const VLQ_BASE_MASK = (1 << VLQ_BASE_SHIFT) - 1;
+const VLQ_CONTINUATION_BIT = 1 << VLQ_BASE_SHIFT;
+
+// Item tags of the "Scopes" proposal, base64 digits of their numeric values.
+const TAG_EMPTY = "A";
+const TAG_ORIGINAL_SCOPE_START = "B";
+const TAG_ORIGINAL_SCOPE_END = "C";
+const TAG_ORIGINAL_SCOPE_VARIABLES = "D";
+const TAG_GENERATED_RANGE_START = "E";
+const TAG_GENERATED_RANGE_END = "F";
+const TAG_GENERATED_RANGE_BINDINGS = "G";
+
+const ORIGINAL_SCOPE_FLAG_HAS_KIND = 0x2;
+const GENERATED_RANGE_FLAG_HAS_LINE = 0x1;
+const GENERATED_RANGE_FLAG_HAS_DEFINITION = 0x2;
+
+/**
+ * Every scope webpack emits describes one module, which the proposal's
+ * JavaScript vocabulary calls a module scope.
+ */
+const MODULE_SCOPE_KIND = "Module";
+
+/**
+ * @param {number} value non-negative value
+ * @returns {string} base64 VLQ digits
+ */
+const encodeUnsigned = (value) => {
+	let result = "";
+	let rest = value;
+	for (;;) {
+		const digit = rest & VLQ_BASE_MASK;
+		rest >>>= VLQ_BASE_SHIFT;
+		if (rest === 0) return result + BASE64_CHARS[digit];
+		result += BASE64_CHARS[VLQ_CONTINUATION_BIT + digit];
+	}
+};
+
+/**
+ * @param {number} value value of either sign
+ * @returns {string} base64 VLQ digits
+ */
+const encodeSigned = (value) =>
+	encodeUnsigned(value >= 0 ? 2 * value : 1 - 2 * value);
+
+/**
+ * Walks the map's segments in generated order, reporting each one's source and
+ * original line. A segment with no source position reports `sourceIndex` -1,
+ * which ends whatever run precedes it.
+ * @param {string} mappings the map's `mappings` field
+ * @param {(generatedLine: number, generatedColumn: number, sourceIndex: number, originalLine: number) => void} onSegment called per segment
+ * @returns {number} the last generated line the mappings reach
+ */
+const forEachMapping = (mappings, onSegment) => {
+	let generatedLine = 0;
+	let generatedColumn = 0;
+	let sourceIndex = 0;
+	let originalLine = 0;
+	let position = 0;
+	const { length } = mappings;
+	/** @type {number[]} */
+	const fields = [];
+	while (position < length) {
+		const char = mappings.charCodeAt(position);
+		if (char === 59 /* ; */) {
+			generatedLine++;
+			generatedColumn = 0;
+			position++;
+			continue;
+		}
+		if (char === 44 /* , */) {
+			position++;
+			continue;
+		}
+		fields.length = 0;
+		while (position < length) {
+			const next = mappings.charCodeAt(position);
+			if (next === 59 || next === 44) break;
+			let value = 0;
+			let shift = 0;
+			let digit;
+			do {
+				digit = BASE64_VALUES[mappings.charCodeAt(position++)];
+				// A digit outside the alphabet cannot be recovered from, and
+				// pretending otherwise would misplace every later segment.
+				if (digit < 0) return generatedLine;
+				value += (digit & VLQ_BASE_MASK) << shift;
+				shift += VLQ_BASE_SHIFT;
+			} while (digit & VLQ_CONTINUATION_BIT);
+			fields.push(value & 1 ? -(value >>> 1) : value >>> 1);
+		}
+		if (fields.length === 0) continue;
+		generatedColumn += fields[0];
+		if (fields.length >= 4) {
+			sourceIndex += fields[1];
+			originalLine += fields[2];
+			onSegment(generatedLine, generatedColumn, sourceIndex, originalLine);
+		} else {
+			onSegment(generatedLine, generatedColumn, -1, -1);
+		}
+	}
+	return generatedLine;
+};
+
+/**
+ * Collects, segment by segment, the generated runs each source explains and how
+ * far into it the map reaches. Both lines are counted from zero, so a caller
+ * whose lines start at one subtracts before feeding a segment in.
+ * @param {number=} sourceCount number of entries in the map's `sources`, when known
+ * @returns {{ add: (generatedLine: number, generatedColumn: number, sourceIndex: number, originalLine: number) => void, finish: (lastLine: number) => SourceScope[] }} collector
+ */
+const createScopeCollector = (sourceCount) => {
+	/** @type {Map<number, SourceScope>} */
+	const scopes = new Map();
+	let openSource = -1;
+	/** @type {SourceScope | undefined} */
+	let openScope;
+	/**
+	 * @param {number} line generated line the run ends at
+	 * @param {number} column generated column the run ends at
+	 * @returns {void}
+	 */
+	const closeRun = (line, column) => {
+		if (openScope === undefined) return;
+		openScope.rangeEnds.push({ line, column });
+		openScope = undefined;
+		openSource = -1;
+	};
+	return {
+		add(generatedLine, generatedColumn, sourceIndex, originalLine) {
+			// A segment naming no source reports -1, which is also what no open
+			// run reports, so the run has to be there before it is extended.
+			if (openScope !== undefined && sourceIndex === openSource) {
+				openScope.originalEnd.line = Math.max(
+					openScope.originalEnd.line,
+					originalLine + 1,
+				);
+				return;
+			}
+			closeRun(generatedLine, generatedColumn);
+			if (
+				sourceIndex < 0 ||
+				(sourceCount !== undefined && sourceIndex >= sourceCount)
+			) {
+				return;
+			}
+			let scope = scopes.get(sourceIndex);
+			if (scope === undefined) {
+				scope = {
+					sourceIndex,
+					variables: [],
+					values: [],
+					originalEnd: { line: originalLine + 1, column: 0 },
+					rangeStarts: [],
+					rangeEnds: [],
+				};
+				scopes.set(sourceIndex, scope);
+			} else {
+				scope.originalEnd.line = Math.max(
+					scope.originalEnd.line,
+					originalLine + 1,
+				);
+			}
+			scope.rangeStarts.push({ line: generatedLine, column: generatedColumn });
+			openScope = scope;
+			openSource = sourceIndex;
+		},
+		finish(lastLine) {
+			closeRun(lastLine, 0);
+			return [...scopes.values()].sort((a, b) => a.sourceIndex - b.sourceIndex);
+		},
+	};
+};
+
+/**
+ * Groups a finished map's segments into one entry per source. Prefer the
+ * collector when the segments are still being written, which saves decoding
+ * back what was just encoded.
+ * @param {string} mappings the map's `mappings` field
+ * @param {number} sourceCount number of entries in the map's `sources`
+ * @returns {SourceScope[]} one entry per source that the mappings reach, in source order
+ */
+const collectSourceScopes = (mappings, sourceCount) => {
+	const collector = createScopeCollector(sourceCount);
+	const lastLine = forEachMapping(mappings, collector.add);
+	return collector.finish(lastLine + 1);
+};
+
+/**
+ * Encodes the scope tree into the `scopes` field of the proposal, appending any
+ * name it needs to the map's `names`.
+ * @param {SourceScope[]} scopes the scopes to encode, in source order
+ * @param {number} sourceCount number of entries in the map's `sources`
+ * @param {string[]} names the map's `names`, extended in place
+ * @returns {string} the encoded `scopes` field
+ */
+const encodeScopes = (scopes, sourceCount, names) => {
+	/** @type {Map<string, number>} */
+	const nameToIndex = new Map();
+	for (let index = 0; index < names.length; index++) {
+		if (!nameToIndex.has(names[index])) nameToIndex.set(names[index], index);
+	}
+	/**
+	 * @param {string} name the name to resolve
+	 * @returns {number} its index in `names`
+	 */
+	const nameIndex = (name) => {
+		const existing = nameToIndex.get(name);
+		if (existing !== undefined) return existing;
+		const added = names.length;
+		names.push(name);
+		nameToIndex.set(name, added);
+		return added;
+	};
+
+	/** @type {Map<number, SourceScope>} */
+	const scopeBySource = new Map();
+	for (const scope of scopes) scopeBySource.set(scope.sourceIndex, scope);
+
+	/** @type {string[]} */
+	const items = [];
+	// The three running indices the proposal encodes names and definitions
+	// against. Only the position pair restarts per source.
+	let lastKind = 0;
+	let lastVariable = 0;
+	let lastDefinition = 0;
+	let scopeCount = 0;
+	/** @type {Map<number, number>} */
+	const scopeIndexBySource = new Map();
+
+	for (let sourceIndex = 0; sourceIndex < sourceCount; sourceIndex++) {
+		const scope = scopeBySource.get(sourceIndex);
+		if (scope === undefined || scope.variables.length === 0) {
+			items.push(TAG_EMPTY);
+			continue;
+		}
+		const kind = nameIndex(MODULE_SCOPE_KIND);
+		items.push(
+			TAG_ORIGINAL_SCOPE_START +
+				encodeUnsigned(ORIGINAL_SCOPE_FLAG_HAS_KIND) +
+				encodeUnsigned(0) +
+				encodeUnsigned(0) +
+				encodeSigned(kind - lastKind),
+		);
+		lastKind = kind;
+		let variables = TAG_ORIGINAL_SCOPE_VARIABLES;
+		for (const variable of scope.variables) {
+			const index = nameIndex(variable);
+			variables += encodeSigned(index - lastVariable);
+			lastVariable = index;
+		}
+		items.push(variables);
+		items.push(
+			TAG_ORIGINAL_SCOPE_END +
+				encodeUnsigned(scope.originalEnd.line) +
+				encodeUnsigned(scope.originalEnd.column),
+		);
+		scopeIndexBySource.set(sourceIndex, scopeCount++);
+	}
+
+	/** @type {{ start: ScopePosition, end: ScopePosition, scope: SourceScope }[]} */
+	const ranges = [];
+	for (const scope of scopes) {
+		if (!scopeIndexBySource.has(scope.sourceIndex)) continue;
+		for (let index = 0; index < scope.rangeStarts.length; index++) {
+			ranges.push({
+				start: scope.rangeStarts[index],
+				end: scope.rangeEnds[index],
+				scope,
+			});
+		}
+	}
+	ranges.sort(
+		(a, b) => a.start.line - b.start.line || a.start.column - b.start.column,
+	);
+
+	let lastLine = 0;
+	let lastColumn = 0;
+	/**
+	 * Encodes a position against the running one, reporting whether it needed a
+	 * line of its own. A line is only carried when it moved forward, and then
+	 * the column is absolute rather than relative.
+	 * @param {ScopePosition} position the position to encode
+	 * @returns {[boolean, string]} whether a line is carried, and the digits
+	 */
+	const encodePosition = (position) => {
+		const line = position.line - lastLine;
+		const carriesLine = line > 0;
+		const column = carriesLine ? position.column : position.column - lastColumn;
+		lastLine = position.line;
+		lastColumn = position.column;
+		return [
+			carriesLine,
+			(carriesLine ? encodeUnsigned(line) : "") + encodeUnsigned(column),
+		];
+	};
+
+	for (const { start, end, scope } of ranges) {
+		const definition =
+			/** @type {number} */
+			(scopeIndexBySource.get(scope.sourceIndex));
+		const [startCarriesLine, startDigits] = encodePosition(start);
+		items.push(
+			TAG_GENERATED_RANGE_START +
+				encodeUnsigned(
+					GENERATED_RANGE_FLAG_HAS_DEFINITION |
+						(startCarriesLine ? GENERATED_RANGE_FLAG_HAS_LINE : 0),
+				) +
+				startDigits +
+				encodeSigned(definition - lastDefinition),
+		);
+		lastDefinition = definition;
+		let bindings = TAG_GENERATED_RANGE_BINDINGS;
+		for (const value of scope.values) {
+			bindings += encodeUnsigned(value === "" ? 0 : nameIndex(value) + 1);
+		}
+		items.push(bindings);
+		// An end item carries no flags: one digit is a column, two a line and a
+		// column, which is what tells the reader whether the line moved.
+		items.push(TAG_GENERATED_RANGE_END + encodePosition(end)[1]);
+	}
+	return items.join(",");
+};
+
+/**
+ * Adds the `scopes` field of the "Scopes" proposal to a source map, naming for
+ * each source the bindings a debugger cannot resolve on its own and the
+ * generated expression each one evaluates to. Does nothing when no source
+ * contributes a binding.
+ * @param {RawSourceMap} sourceMap the map to extend in place
+ * @param {(sourceIndex: number) => Map<string, string> | undefined} getBindings binding expressions per source
+ * @returns {void}
+ */
+const addScopesToSourceMap = (sourceMap, getBindings) => {
+	if (!sourceMap.mappings || !sourceMap.sources) return;
+	const sourceCount = sourceMap.sources.length;
+	const scopes = collectSourceScopes(sourceMap.mappings, sourceCount);
+	let any = false;
+	for (const scope of scopes) {
+		const bindings = getBindings(scope.sourceIndex);
+		if (bindings === undefined || bindings.size === 0) continue;
+		for (const [name, value] of bindings) {
+			scope.variables.push(name);
+			scope.values.push(value);
+		}
+		any = true;
+	}
+	if (!any) return;
+	const names = sourceMap.names || (sourceMap.names = []);
+	sourceMap.scopes = encodeScopes(scopes, sourceCount, names);
+};
+
+/**
+ * Builds the `scopes` field while a map is being written, so the segments are
+ * read as they are produced rather than decoded back out of `mappings`. Lines
+ * are the one-based ones the chunk stream reports.
+ * @returns {{ add: (generatedLine: number, generatedColumn: number, sourceIndex: number, originalLine: number) => void, addSource: (sourceIndex: number, scopeBindings?: ScopeBindings) => void, finish: (map: RawSourceMap, generatedLine: number) => void }} writer
+ */
+const createScopesWriter = () => {
+	const collector = createScopeCollector();
+	/** @type {Map<number, ScopeBindings>} */
+	const bindingsBySource = new Map();
+	return {
+		add(generatedLine, generatedColumn, sourceIndex, originalLine) {
+			collector.add(
+				generatedLine - 1,
+				generatedColumn,
+				sourceIndex,
+				originalLine - 1,
+			);
+		},
+		addSource(sourceIndex, scopeBindings) {
+			if (scopeBindings !== undefined && scopeBindings.size > 0) {
+				bindingsBySource.set(sourceIndex, scopeBindings);
+			}
+		},
+		finish(map, generatedLine) {
+			if (bindingsBySource.size === 0) return;
+			const scopes = collector.finish(generatedLine - 1);
+			let any = false;
+			for (const scope of scopes) {
+				const bindings = bindingsBySource.get(scope.sourceIndex);
+				if (bindings === undefined) continue;
+				for (const [name, value] of bindings) {
+					scope.variables.push(name);
+					scope.values.push(value);
+				}
+				any = true;
+			}
+			if (!any) return;
+			const names = map.names || (map.names = []);
+			map.scopes = encodeScopes(scopes, map.sources.length, names);
+		},
+	};
+};
+
+module.exports.addScopesToSourceMap = addScopesToSourceMap;
+module.exports.collectSourceScopes = collectSourceScopes;
+module.exports.createScopeCollector = createScopeCollector;
+module.exports.createScopesWriter = createScopesWriter;
+module.exports.encodeScopes = encodeScopes;

--- a/lib/helpers/streamAndGetSourceAndMap.js
+++ b/lib/helpers/streamAndGetSourceAndMap.js
@@ -6,7 +6,6 @@
 "use strict";
 
 const { createMappingsWriter } = require("./createMappingsSerializer");
-const { createScopesWriter } = require("./scopes");
 const streamChunks = require("./streamChunks");
 
 /** @typedef {import("../Source").RawSourceMap} RawSourceMap */
@@ -16,6 +15,20 @@ const streamChunks = require("./streamChunks");
 /** @typedef {import("./streamChunks").OnSource} OnSource */
 /** @typedef {import("./streamChunks").Options} Options */
 /** @typedef {import("./streamChunks").SourceMaybeWithStreamChunksFunction} SourceMaybeWithStreamChunksFunction */
+
+/** @type {typeof import("./scopes") | undefined} */
+let scopesHelpers;
+
+/**
+ * Loads the scopes helpers on first use. They are only reachable through the
+ * `scopes` option, so requiring them eagerly would put the encoder in the
+ * module graph of every caller that never asks for the field.
+ * @returns {ReturnType<typeof import("./scopes").createScopesWriter>} writer
+ */
+const createScopesWriter = () => {
+	if (scopesHelpers === undefined) scopesHelpers = require("./scopes");
+	return scopesHelpers.createScopesWriter();
+};
 
 /**
  * @param {SourceMaybeWithStreamChunksFunction} inputSource input source

--- a/lib/helpers/streamAndGetSourceAndMap.js
+++ b/lib/helpers/streamAndGetSourceAndMap.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const { createMappingsWriter } = require("./createMappingsSerializer");
+const { createScopesWriter } = require("./scopes");
 const streamChunks = require("./streamChunks");
 
 /** @typedef {import("../Source").RawSourceMap} RawSourceMap */
@@ -40,6 +41,8 @@ const streamAndGetSourceAndMap = (
 	const potentialNames = [];
 	const mappingsWriter = createMappingsWriter({ ...options, columns: true });
 	const addMapping = mappingsWriter.add;
+	const scopesWriter =
+		options && options.scopes ? createScopesWriter() : undefined;
 	const finalSource = Boolean(options && options.finalSource);
 	// The caller may have passed `source: false` (getMap does), but this
 	// helper caches the source text, so the inner stream must produce it.
@@ -68,6 +71,14 @@ const streamAndGetSourceAndMap = (
 				originalColumn,
 				nameIndex,
 			);
+			if (scopesWriter !== undefined) {
+				scopesWriter.add(
+					generatedLine,
+					generatedColumn,
+					sourceIndex,
+					originalLine,
+				);
+			}
 			return onChunk(
 				finalSource ? undefined : chunk,
 				generatedLine,
@@ -78,7 +89,7 @@ const streamAndGetSourceAndMap = (
 				nameIndex,
 			);
 		},
-		(sourceIndex, source, sourceContent) => {
+		(sourceIndex, source, sourceContent, scopeBindings) => {
 			while (potentialSources.length < sourceIndex) {
 				potentialSources.push(null);
 			}
@@ -89,7 +100,10 @@ const streamAndGetSourceAndMap = (
 				}
 				potentialSourcesContent[sourceIndex] = sourceContent;
 			}
-			return onSource(sourceIndex, source, sourceContent);
+			if (scopesWriter !== undefined) {
+				scopesWriter.addSource(sourceIndex, scopeBindings);
+			}
+			return onSource(sourceIndex, source, sourceContent, scopeBindings);
 		},
 		(nameIndex, name) => {
 			while (potentialNames.length < nameIndex) {
@@ -101,6 +115,25 @@ const streamAndGetSourceAndMap = (
 	);
 	const resultSource = source !== undefined ? source : code;
 	const mappings = mappingsWriter.finish();
+	/** @type {RawSourceMap | null} */
+	let map = null;
+	if (mappings.length > 0) {
+		map = {
+			version: 3,
+			file: "x",
+			mappings,
+			// We handle broken sources as `null`, in spec this field should be string, but no information what we should do in such cases if we change type it will be breaking change
+			sources: /** @type {string[]} */ (potentialSources),
+			sourcesContent:
+				potentialSourcesContent.length > 0
+					? /** @type {string[]} */ (potentialSourcesContent)
+					: undefined,
+			names: /** @type {string[]} */ (potentialNames),
+		};
+		if (scopesWriter !== undefined) {
+			scopesWriter.finish(map, generatedLine || 0);
+		}
+	}
 
 	return {
 		result: {
@@ -109,21 +142,7 @@ const streamAndGetSourceAndMap = (
 			source: finalSource ? resultSource : undefined,
 		},
 		source: resultSource,
-		map:
-			mappings.length > 0
-				? {
-						version: 3,
-						file: "x",
-						mappings,
-						// We handle broken sources as `null`, in spec this field should be string, but no information what we should do in such cases if we change type it will be breaking change
-						sources: /** @type {string[]} */ (potentialSources),
-						sourcesContent:
-							potentialSourcesContent.length > 0
-								? /** @type {string[]} */ (potentialSourcesContent)
-								: undefined,
-						names: /** @type {string[]} */ (potentialNames),
-					}
-				: null,
+		map,
 	};
 };
 

--- a/lib/helpers/streamChunks.js
+++ b/lib/helpers/streamChunks.js
@@ -11,10 +11,11 @@ const streamChunksOfSourceMap = require("./streamChunksOfSourceMap");
 /** @typedef {import("../Source")} Source */
 /** @typedef {import("./getGeneratedSourceInfo").GeneratedSourceInfo} GeneratedSourceInfo */
 /** @typedef {(chunk: string | undefined, generatedLine: number, generatedColumn: number, sourceIndex: number, originalLine: number, originalColumn: number, nameIndex: number) => void} OnChunk */
-/** @typedef {(sourceIndex: number, source: string | null, sourceContent: string | undefined) => void} OnSource */
+/** @typedef {Map<string, string>} ScopeBindings */
+/** @typedef {(sourceIndex: number, source: string | null, sourceContent: string | undefined, scopeBindings?: ScopeBindings) => void} OnSource */
 /** @typedef {(nameIndex: number, name: string) => void} OnName */
 
-/** @typedef {{ source?: boolean, finalSource?: boolean, columns?: boolean }} Options */
+/** @typedef {{ source?: boolean, finalSource?: boolean, columns?: boolean, scopes?: boolean }} Options */
 
 /**
  * @callback StreamChunksFunction

--- a/lib/helpers/streamChunksOfCombinedSourceMap.js
+++ b/lib/helpers/streamChunksOfCombinedSourceMap.js
@@ -301,7 +301,7 @@ const streamChunksOfCombinedSourceMap = (
 				);
 			}
 		},
-		(i, source, sourceContent) => {
+		(i, source, sourceContent, scopeBindings) => {
 			if (source === innerSourceName) {
 				outerSourceIndex = i;
 				if (innerSource !== undefined) sourceContent = innerSource;
@@ -353,7 +353,7 @@ const streamChunksOfCombinedSourceMap = (
 				let globalIndex = sourceMapping.get(source);
 				if (globalIndex === undefined) {
 					sourceMapping.set(source, (globalIndex = sourceMapping.size));
-					onSource(globalIndex, source, sourceContent);
+					onSource(globalIndex, source, sourceContent, scopeBindings);
 				}
 				sourceIndexMapping[i] = globalIndex;
 			}

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,6 +112,9 @@ module.exports = mergeExports(
 			return require("./CompatSource");
 		},
 		util: {
+			get scopes() {
+				return require("./helpers/scopes");
+			},
 			get stringBufferUtils() {
 				return require("./helpers/stringBufferUtils");
 			},

--- a/test/scopes.js
+++ b/test/scopes.js
@@ -1,0 +1,160 @@
+"use strict";
+
+const {
+	CachedSource,
+	ConcatSource,
+	OriginalSource,
+	ReplaceSource,
+} = require("../");
+const { collectSourceScopes, encodeScopes } = require("../lib/helpers/scopes");
+
+/** @typedef {import("../lib/Source").MapOptions} MapOptions */
+/** @typedef {import("../lib/Source").RawSourceMap} RawSourceMap */
+/** @typedef {import("../lib/helpers/streamChunks").ScopeBindings} ScopeBindings */
+
+/**
+ * @param {{ map: (options?: MapOptions) => RawSourceMap | null }} source source
+ * @param {MapOptions} options map options
+ * @returns {RawSourceMap} the map, which every case here produces
+ */
+const mapOf = (source, options) =>
+	/** @type {RawSourceMap} */ (source.map(options));
+
+/**
+ * @param {string} name source name
+ * @param {ScopeBindings=} bindings bindings the source declares
+ * @returns {OriginalSource} source
+ */
+const sourceWithBindings = (name, bindings) =>
+	new OriginalSource("const a = mutable;\nfn();\n", name, bindings);
+
+const BINDINGS = new Map([
+	["mutable", "ns.mutable"],
+	["fn", "ns.fn"],
+]);
+
+describe("scopes", () => {
+	it("emits nothing without the option", () => {
+		const map = mapOf(sourceWithBindings("lib.js", BINDINGS), {
+			columns: true,
+		});
+		expect(map.scopes).toBeUndefined();
+	});
+
+	it("emits nothing when no source declares a binding", () => {
+		const map = mapOf(sourceWithBindings("lib.js"), {
+			columns: true,
+			scopes: true,
+		});
+		expect(map.scopes).toBeUndefined();
+	});
+
+	it("names each binding and the expression it reads", () => {
+		const map = mapOf(sourceWithBindings("lib.js", BINDINGS), {
+			columns: true,
+			scopes: true,
+		});
+		expect(typeof map.scopes).toBe("string");
+		expect(map.names).toContain("mutable");
+		expect(map.names).toContain("ns.mutable");
+		expect(map.names).toContain("fn");
+		expect(map.names).toContain("ns.fn");
+	});
+
+	it("carries bindings through ConcatSource and ReplaceSource", () => {
+		const replaced = new ReplaceSource(sourceWithBindings("lib.js", BINDINGS));
+		replaced.replace(0, 4, "let");
+		const map = mapOf(
+			new ConcatSource(new OriginalSource("x();\n", "entry.js"), replaced),
+			{ columns: true, scopes: true },
+		);
+		expect(typeof map.scopes).toBe("string");
+		expect(map.names).toContain("ns.mutable");
+	});
+
+	it("keeps the map's own names ahead of the ones it adds", () => {
+		const map = mapOf(
+			new ConcatSource(
+				new OriginalSource("x();\n", "entry.js"),
+				sourceWithBindings("lib.js", BINDINGS),
+			),
+			{ columns: true, scopes: true },
+		);
+		expect(map.names.indexOf("mutable")).toBeGreaterThanOrEqual(0);
+		expect(new Set(map.names).size).toBe(map.names.length);
+	});
+
+	it("reports the same field through sourceAndMap", () => {
+		const source = new ConcatSource(sourceWithBindings("lib.js", BINDINGS));
+		const options = { columns: true, scopes: true };
+		expect(
+			/** @type {RawSourceMap} */ (source.sourceAndMap(options).map).scopes,
+		).toBe(mapOf(source, options).scopes);
+	});
+
+	describe("cachedSource", () => {
+		/**
+		 * @returns {CachedSource} a cached source over one module with bindings
+		 */
+		const cached = () =>
+			new CachedSource(
+				new ConcatSource(sourceWithBindings("lib.js", BINDINGS)),
+			);
+
+		it("does not serve a scopes-less cached map to a scopes request", () => {
+			const source = cached();
+			expect(mapOf(source, { columns: true }).scopes).toBeUndefined();
+			expect(
+				mapOf(source, { columns: true, scopes: true }).scopes,
+			).toBeDefined();
+		});
+
+		it("does not leak scopes into a request that did not ask", () => {
+			const source = cached();
+			expect(
+				mapOf(source, { columns: true, scopes: true }).scopes,
+			).toBeDefined();
+			expect(mapOf(source, { columns: true }).scopes).toBeUndefined();
+		});
+
+		it("still reports bindings once the source has been streamed", () => {
+			const module = new CachedSource(sourceWithBindings("lib.js", BINDINGS));
+			module.map({ columns: true });
+			module.source();
+			const map = mapOf(
+				new ConcatSource(new OriginalSource("x();\n", "entry.js"), module),
+				{ columns: true, scopes: true },
+			);
+			expect(map.names).toContain("ns.mutable");
+		});
+	});
+
+	describe("encoding", () => {
+		it("reads back the runs a finished map describes", () => {
+			const map = mapOf(sourceWithBindings("lib.js", BINDINGS), {
+				columns: true,
+			});
+			const scopes = collectSourceScopes(map.mappings, map.sources.length);
+			expect(scopes).toHaveLength(1);
+			expect(scopes[0].sourceIndex).toBe(0);
+			expect(scopes[0].rangeStarts).toHaveLength(scopes[0].rangeEnds.length);
+		});
+
+		it("agrees with the field built while the map was written", () => {
+			const source = sourceWithBindings("lib.js", BINDINGS);
+			const streamed = mapOf(source, { columns: true, scopes: true });
+			const map = mapOf(source, { columns: true });
+			const scopes = collectSourceScopes(map.mappings, map.sources.length);
+			for (const scope of scopes) {
+				for (const [name, value] of BINDINGS) {
+					scope.variables.push(name);
+					scope.values.push(value);
+				}
+			}
+			const names = [...map.names];
+			expect(encodeScopes(scopes, map.sources.length, names)).toBe(
+				streamed.scopes,
+			);
+		});
+	});
+});

--- a/test/scopes.js
+++ b/test/scopes.js
@@ -96,6 +96,14 @@ describe("scopes", () => {
 		).toBe(mapOf(source, options).scopes);
 	});
 
+	it("exposes the helpers on the public util export", () => {
+		const { util } = require("../");
+
+		expect(util.scopes.addScopesToSourceMap).toBe(addScopesToSourceMap);
+		expect(util.scopes.collectSourceScopes).toBe(collectSourceScopes);
+		expect(util.scopes.encodeScopes).toBe(encodeScopes);
+	});
+
 	describe("cachedSource", () => {
 		/**
 		 * @returns {CachedSource} a cached source over one module with bindings

--- a/test/scopes.js
+++ b/test/scopes.js
@@ -6,7 +6,11 @@ const {
 	OriginalSource,
 	ReplaceSource,
 } = require("../");
-const { collectSourceScopes, encodeScopes } = require("../lib/helpers/scopes");
+const {
+	addScopesToSourceMap,
+	collectSourceScopes,
+	encodeScopes,
+} = require("../lib/helpers/scopes");
 
 /** @typedef {import("../lib/Source").MapOptions} MapOptions */
 /** @typedef {import("../lib/Source").RawSourceMap} RawSourceMap */
@@ -155,6 +159,91 @@ describe("scopes", () => {
 			expect(encodeScopes(scopes, map.sources.length, names)).toBe(
 				streamed.scopes,
 			);
+		});
+	});
+
+	describe("addScopesToSourceMap", () => {
+		/**
+		 * @param {string} mappings mappings field
+		 * @param {string[]=} sources sources field
+		 * @returns {RawSourceMap} a map shaped like one another tool produced
+		 */
+		const mapOf_ = (mappings, sources = ["lib.js"]) => ({
+			version: 3,
+			file: "x",
+			sources,
+			names: [],
+			mappings,
+		});
+
+		it("does nothing when the map has no mappings", () => {
+			const map = mapOf_("");
+			addScopesToSourceMap(map, () => BINDINGS);
+			expect(map.scopes).toBeUndefined();
+		});
+
+		it("does nothing when no source is asked for bindings", () => {
+			const map = mapOf_("AAAA");
+			addScopesToSourceMap(map, () => undefined);
+			expect(map.scopes).toBeUndefined();
+		});
+
+		it("does nothing when a source reports an empty set", () => {
+			const map = mapOf_("AAAA");
+			addScopesToSourceMap(map, () => new Map());
+			expect(map.scopes).toBeUndefined();
+		});
+
+		it("names the bindings a finished map's source declares", () => {
+			const map = mapOf_("AAAA,IAAI");
+			addScopesToSourceMap(map, () => BINDINGS);
+			expect(typeof map.scopes).toBe("string");
+			expect(map.names).toContain("mutable");
+			expect(map.names).toContain("ns.mutable");
+		});
+
+		it("skips a segment that names no source", () => {
+			// the second segment carries only a column delta, so it maps nowhere
+			const map = mapOf_("AAAA,C");
+			addScopesToSourceMap(map, () => BINDINGS);
+			expect(typeof map.scopes).toBe("string");
+		});
+
+		it("skips a segment whose source index the map does not have", () => {
+			// the second segment steps sourceIndex to 1, past the single source
+			const map = mapOf_("AAAA,ACAA");
+			addScopesToSourceMap(map, () => BINDINGS);
+			expect(typeof map.scopes).toBe("string");
+		});
+
+		it("reaches the furthest original line a source explains", () => {
+			// one source, interrupted and resumed, so its end has to be extended
+			const map = mapOf_("AAAA;ACAA;ADEA", ["lib.js", "other.js"]);
+			addScopesToSourceMap(map, (i) => (i === 0 ? BINDINGS : undefined));
+			const scopes = collectSourceScopes(map.mappings, 2);
+			expect(scopes[0].originalEnd.line).toBeGreaterThan(1);
+		});
+
+		it("reuses a name the map already carries", () => {
+			const map = mapOf_("AAAA");
+			map.names = ["mutable", "mutable"];
+			addScopesToSourceMap(map, () => new Map([["mutable", "ns.mutable"]]));
+			expect(map.names.filter((n) => n === "mutable")).toHaveLength(2);
+			expect(map.names).toContain("ns.mutable");
+		});
+
+		it("encodes a value too large for one digit", () => {
+			// forty lines puts the scope's end past what one base64 digit holds
+			const map = mapOf_(Array.from({ length: 40 }, () => "AACA").join(";"));
+			addScopesToSourceMap(map, () => BINDINGS);
+			expect(typeof map.scopes).toBe("string");
+			expect(/** @type {string} */ (map.scopes).length).toBeGreaterThan(10);
+		});
+
+		it("orders the generated ranges it emits", () => {
+			const map = mapOf_("AAAA,IAAI;AAAA,IAAI;AAAA,IAAI");
+			addScopesToSourceMap(map, () => BINDINGS);
+			expect(typeof map.scopes).toBe("string");
 		});
 	});
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -92,6 +92,7 @@ declare class CachedSource extends Source {
 			sourceIndex: number,
 			source: null | string,
 			sourceContent?: string,
+			scopeBindings?: Map<string, string>,
 		) => void,
 		onName: (nameIndex: number, name: string) => void,
 	): GeneratedSourceInfo;
@@ -136,6 +137,7 @@ declare class ConcatSource extends Source {
 			sourceIndex: number,
 			source: null | string,
 			sourceContent?: string,
+			scopeBindings?: Map<string, string>,
 		) => void,
 		onName: (nameIndex: number, name: string) => void,
 	): GeneratedSourceInfo;
@@ -178,9 +180,18 @@ declare interface MapOptions {
 	 * is module
 	 */
 	module?: boolean;
+
+	/**
+	 * emit the `scopes` field from the bindings the sources declare
+	 */
+	scopes?: boolean;
 }
 declare class OriginalSource extends Source {
-	constructor(value: string | Buffer, name: string);
+	constructor(
+		value: string | Buffer,
+		name: string,
+		scopeBindings?: Map<string, string>,
+	);
 	getName(): string;
 	streamChunks(
 		options: StreamChunksOptions,
@@ -197,6 +208,7 @@ declare class OriginalSource extends Source {
 			sourceIndex: number,
 			source: null | string,
 			sourceContent?: string,
+			scopeBindings?: Map<string, string>,
 		) => void,
 		_onName: (nameIndex: number, name: string) => void,
 	): GeneratedSourceInfo;
@@ -220,6 +232,7 @@ declare class PrefixSource extends Source {
 			sourceIndex: number,
 			source: null | string,
 			sourceContent?: string,
+			scopeBindings?: Map<string, string>,
 		) => void,
 		onName: (nameIndex: number, name: string) => void,
 	): GeneratedSourceInfo;
@@ -242,6 +255,7 @@ declare class RawSource extends Source {
 			sourceIndex: number,
 			source: null | string,
 			sourceContent?: string,
+			scopeBindings?: Map<string, string>,
 		) => void,
 		onName: (nameIndex: number, name: string) => void,
 	): GeneratedSourceInfo;
@@ -291,6 +305,11 @@ declare interface RawSourceMap {
 	 * ignore list
 	 */
 	ignoreList?: number[];
+
+	/**
+	 * encoded `scopes` field of the "Scopes" proposal
+	 */
+	scopes?: string;
 }
 declare class ReplaceSource extends Source {
 	constructor(source: Source, name?: string);
@@ -314,6 +333,7 @@ declare class ReplaceSource extends Source {
 			sourceIndex: number,
 			source: null | string,
 			sourceContent?: string,
+			scopeBindings?: Map<string, string>,
 		) => void,
 		onName: (nameIndex: number, name: string) => void,
 	): GeneratedSourceInfo;
@@ -326,6 +346,17 @@ declare class Replacement {
 	content: string;
 	name?: string;
 	index?: number;
+}
+declare interface ScopePosition {
+	/**
+	 * line
+	 */
+	line: number;
+
+	/**
+	 * column
+	 */
+	column: number;
 }
 declare class SizeOnlySource extends Source {
 	constructor(size: number);
@@ -437,18 +468,88 @@ declare class SourceMapSource extends Source {
 			sourceIndex: number,
 			source: null | string,
 			sourceContent?: string,
+			scopeBindings?: Map<string, string>,
 		) => void,
 		onName: (nameIndex: number, name: string) => void,
 	): GeneratedSourceInfo;
+}
+declare interface SourceScope {
+	/**
+	 * index into the map's `sources`
+	 */
+	sourceIndex: number;
+
+	/**
+	 * the names the source declares
+	 */
+	variables: string[];
+
+	/**
+	 * the generated expression each name evaluates to
+	 */
+	values: string[];
+
+	/**
+	 * end of the original scope, exclusive
+	 */
+	originalEnd: ScopePosition;
+
+	/**
+	 * start of each generated range, inclusive
+	 */
+	rangeStarts: ScopePosition[];
+
+	/**
+	 * end of each generated range, exclusive
+	 */
+	rangeEnds: ScopePosition[];
 }
 type SourceValue = string | Buffer;
 declare interface StreamChunksOptions {
 	source?: boolean;
 	finalSource?: boolean;
 	columns?: boolean;
+	scopes?: boolean;
 }
 declare namespace exports {
 	export namespace util {
+		export namespace scopes {
+			export let addScopesToSourceMap: (
+				sourceMap: RawSourceMap,
+				getBindings: (sourceIndex: number) => undefined | Map<string, string>,
+			) => void;
+			export let collectSourceScopes: (
+				mappings: string,
+				sourceCount: number,
+			) => SourceScope[];
+			export let createScopeCollector: (sourceCount?: number) => {
+				add: (
+					generatedLine: number,
+					generatedColumn: number,
+					sourceIndex: number,
+					originalLine: number,
+				) => void;
+				finish: (lastLine: number) => SourceScope[];
+			};
+			export let createScopesWriter: () => {
+				add: (
+					generatedLine: number,
+					generatedColumn: number,
+					sourceIndex: number,
+					originalLine: number,
+				) => void;
+				addSource: (
+					sourceIndex: number,
+					scopeBindings?: Map<string, string>,
+				) => void;
+				finish: (map: RawSourceMap, generatedLine: number) => void;
+			};
+			export let encodeScopes: (
+				scopes: SourceScope[],
+				sourceCount: number,
+				names: string[],
+			) => string;
+		}
 		export namespace stringBufferUtils {
 			export let disableDualStringBufferCaching: () => void;
 			export let enableDualStringBufferCaching: () => void;
@@ -472,6 +573,7 @@ declare namespace exports {
 		sourceIndex: number,
 		source: null | string,
 		sourceContent?: string,
+		scopeBindings?: Map<string, string>,
 	) => void;
 	export {
 		Source,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

A bundler rewrites an imported binding into a namespace read, and a source map only maps positions, so a debugger cannot resolve the name the source actually used. This adds `map({ scopes: true })`, emitting the ECMA-426 [Scopes](https://github.com/tc39/ecma426/blob/main/proposals/scopes.md) field: a source declares what its names read through a new third `OriginalSource` argument, the chunk stream carries that beside the source content, and the field is built while the mappings are written rather than decoded back out of them. Needed by webpack/webpack#21999, which otherwise has to carry its own VLQ codec and re-parse every asset's `mappings`.

It also fixes a pre-existing cache bug it would otherwise trip over: `CachedSource`'s fast-path key inspected only `columns`, so any two option sets differing elsewhere collided — with `scopes` that meant a map built without the field could be served to a caller asking for it, and vice versa.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

feat.

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

Yes — `test/scopes.js`: the option is opt-in, bindings survive `ConcatSource`, `ReplaceSource` and a primed `CachedSource`, neither cache order leaks or drops the field, and the streaming encoder is asserted byte-identical to decoding a finished map.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No. `OnSource` gains an optional fourth argument and `MapOptions` an optional `scopes` flag; without it nothing is collected or emitted, and the existing 89,895 tests and 1,373 snapshots pass unchanged.

**If relevant, what needs to be documented once your changes are merged or what have you already documented in this PR?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

`map({ scopes: true })`, the `OriginalSource` third constructor argument, and the `util.scopes` helpers.

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it.
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due to irresponsible use of AI. -->

Yes. Claude Code was used to move the encoder out of webpack, wire the option through the streaming path, and write the tests. The design — a plain boolean option with the bindings riding on the sources, rather than a callback that a cache key cannot see — was mine, and the `CachedSource` bugs above were found by testing that decision rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5WxsJzknrdkVzHV3rL1Uv

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5WxsJzknrdkVzHV3rL1Uv)_